### PR TITLE
replace lines that would break on data.tables

### DIFF
--- a/R/absoluteRisk.R
+++ b/R/absoluteRisk.R
@@ -30,6 +30,7 @@
 #'   covariate profiles.
 absoluteRisk <- function(object, time, newdata = NULL, method = c("quadrature", "montecarlo"), nsamp=100) {
     method <- match.arg(method)
+    meanAR <- FALSE
     # Create hazard function
     lambda <- function(x, fit, newdata) {
         # Note: the offset should be set to zero when estimating the hazard.
@@ -45,8 +46,9 @@ absoluteRisk <- function(object, time, newdata = NULL, method = c("quadrature", 
         }
         newdata <- object$originalData
         colnames(data)[colnames(data) == "event"] <- "status"
-        # Next line will break on data.table
-        newdata <- newdata[,colnames(newdata) != "time"]
+        # Next commented line will break on data.table
+        # newdata <- newdata[, colnames(newdata) != "time"]
+        newdata <- subset(newdata, select = (colnames(newdata) != "time"))
         meanAR <- TRUE
     }
 

--- a/R/sampling.R
+++ b/R/sampling.R
@@ -42,9 +42,6 @@ sampleCaseBase <- function(data, ratio = 10, type = c("uniform", "multinomial"))
         bSeries <- survObj[who, ]
         bSeries[, "status"] <- 0
         bSeries[, "time"] <- runif(b) * bSeries[, "time"]
-        # Next line will break on data.table
-        bSeries <- cbind(bSeries, data[who, colnames(data) != c("time", "event")])
-        bSeries$o <- offset
     }
 
     if (type == "multinomial") {
@@ -61,10 +58,12 @@ sampleCaseBase <- function(data, ratio = 10, type = c("uniform", "multinomial"))
         bSeries <- survObj[who, ]
         bSeries[, "status"] <- 0
         bSeries[, "time"] <- everyDt - pSum[who]
-        # Next line will break on data.table
-        bSeries <- cbind(bSeries, data[who, colnames(data) != c("time", "event")])
-        bSeries$o <- offset
     }
+
+    # Next commented line will break on data.table
+    # bSeries <- cbind(bSeries, data[who, colnames(data) != c("time", "event")])
+    bSeries <- cbind(bSeries, subset(data, select = (colnames(data) != c("time", "event")))[who,])
+    bSeries$o <- offset
 
     cSeries <- data[data$event == 1,]
     # cSeries <- survObj[survObj[, "status"] == 1, ]


### PR DESCRIPTION
instead of subsetting on column names, the function ```subset``` is used. This should behave the same way regardless of whether the object is a ```data.frame``` or a ```data.table```.

This fixes #5.