### PR TITLE
Time variable

### DIFF
--- a/R/sampling.R
+++ b/R/sampling.R
@@ -26,18 +26,18 @@
 #' @export
 sampleCaseBase <- function(data, time, event, ratio = 10, type = c("uniform", "multinomial")) {
     if (missing(time)) {
-        if ("time" %in% colnames(data)) {
-            time <- "time"
+        if (any(grepl("^time", names(data), ignore.case = TRUE))) {
+            time <- grep("^time", names(data), ignore.case = TRUE, value = TRUE)
         } else {
             stop("data does not contain time variable")
         }
     }
     if (missing(event)) {
-        if ("event" %in% colnames(data)) {
-            event <- "event"
+        if (any(grepl("^event", names(data), ignore.case = TRUE))) {
+            event <- grep("^event", names(data), ignore.case = TRUE, value = TRUE)
         } else {
-            if ("status" %in% colnames(data)) {
-                event <- "status"
+            if (any(grepl("^status", names(data), ignore.case = TRUE))) {
+                event <- grep("^status", names(data), ignore.case = TRUE, value = TRUE)
             } else {
                 stop("data does not contain event or status variable")
             }
@@ -49,8 +49,8 @@ sampleCaseBase <- function(data, time, event, ratio = 10, type = c("uniform", "m
     type <- match.arg(type)
     # Create survival object from dataset
     selectTime <- (names(data) == time)
-    survObj <- survival::Surv(subset(data, select=selectTime),
-                              subset(data, select=(names(data) == event)))
+    survObj <- survival::Surv(subset(data, select=selectTime, drop = TRUE),
+                              subset(data, select=(names(data) == event), drop = TRUE))
 
     n <- nrow(survObj) # no. of subjects
     B <- sum(survObj[, "time"])             # total person-time in base
@@ -87,7 +87,8 @@ sampleCaseBase <- function(data, time, event, ratio = 10, type = c("uniform", "m
 
     # Next commented line will break on data.table
     # bSeries <- cbind(bSeries, data[who, colnames(data) != c("time", "event")])
-    bSeries <- cbind(bSeries, subset(data, select = (colnames(data) != c(time, event)))[who,])
+    selectTimeEvent <- (colnames(data) != c(time, event))
+    bSeries <- cbind(bSeries, subset(data, select = selectTimeEvent)[who,])
     names(bSeries)[names(bSeries) == "status"] <- event
 
     cSeries <- data[which(subset(data, select=(names(data) == event)) == 1),]

--- a/R/sampling.R
+++ b/R/sampling.R
@@ -48,7 +48,8 @@ sampleCaseBase <- function(data, time, event, ratio = 10, type = c("uniform", "m
     }
     type <- match.arg(type)
     # Create survival object from dataset
-    survObj <- survival::Surv(subset(data, select=(names(data) == time)),
+    selectTime <- (names(data) == time)
+    survObj <- survival::Surv(subset(data, select=selectTime),
                               subset(data, select=(names(data) == event)))
 
     n <- nrow(survObj) # no. of subjects

--- a/vignettes/smoothHazard.Rmd
+++ b/vignettes/smoothHazard.Rmd
@@ -95,9 +95,7 @@ Next, we use case-base sampling to fit a parametric hazard function via logistic
 
 ```{r eval=TRUE}
 library(casebase)
-library(data.table)
-names(veteran)[names(veteran) == "status"] <- "event"
-model4 <- fitSmoothHazard(event ~ time + karno + diagtime + age + prior +
+model4 <- fitSmoothHazard(status ~ time + karno + diagtime + age + prior +
              celltype + trt, data = veteran, ratio=100, type = "uniform")
 summary(model4)
 ```
@@ -114,7 +112,7 @@ mean(ftime <= 90)
 We can also fit a Weibull hazard by using a logarithmic term for time:
 
 ```{r eval=TRUE}
-model5 <- fitSmoothHazard(event ~ log(time) + karno + diagtime + age + prior +
+model5 <- fitSmoothHazard(status ~ log(time) + karno + diagtime + age + prior +
              celltype + trt, data = veteran, ratio=100, type = "uniform")
 summary(model5)
 ```
@@ -124,7 +122,7 @@ With case-base sampling, it is straightforward to fit a semi-parametric hazard f
 ```{r eval=TRUE}
 # Fit a spline for time
 library(splines)
-model6 <- fitSmoothHazard(event ~ bs(time) + karno + diagtime + age + prior +
+model6 <- fitSmoothHazard(status ~ bs(time) + karno + diagtime + age + prior +
              celltype + trt, data = veteran, ratio=100, type = "uniform")
 summary(model6)
 


### PR DESCRIPTION
The expression triggering the error was the following:
``` r
subset(data, select=(names(data) == time))
```
which was evaluated in such a way that ```time``` was construed as the function in the ```stats``` package, and not the variable defined earlier in the function (recall that using ```subset``` inside a function is part of the 8th circle in the [R inferno](http://www.burns-stat.com/pages/Tutor/R_inferno.pdf)).

The solution I found was to evaluate ```names(data) == time``` before calling the function ```subset```:
``` r
selectTime <- (names(data) == time)
survObj <- survival::Surv(subset(data, select=selectTime, drop = TRUE),
                          subset(data, select=(names(data) == event), drop = TRUE))
```

Fixes Issue #11 