### PR TITLE
Abs risk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test.rds
 data-raw
 references
 .DS_Store
+tests/testthat/Rplots.pdf

--- a/R/hazardPlot.R
+++ b/R/hazardPlot.R
@@ -125,6 +125,9 @@ hazardPlot <- function(object, newdata, type = c("hazard"), xlab = NULL,
     names(newdata)[names(newdata) == 'sequence_of_times'] <- object[["timeVar"]]
 
     newdata$offset <- 0
+    # If gbm was fitted with an offset, predict.gbm ignores it but still gives a warning
+    # The following line silences this warning
+    if (obj_class == "gbm") attr(object$Terms, "offset") <- NULL
 
     preds <- switch (obj_class,
                      glm = {
@@ -207,7 +210,7 @@ hazardPlot <- function(object, newdata, type = c("hazard"), xlab = NULL,
         # rug(object[["originalData"]][[ object[["timeVar"]] ]], col = line.col)
         events <- object[["originalData"]][[object[["eventVar"]] ]]
         rug(object[["originalData"]][which(events==1),,drop=F][[ object[["timeVar"]]  ]],
-            col = line.col)
+            col = line.col, quiet = TRUE) # Silence warnings about clipped values
     }
     return(invisible(newdata))
 }

--- a/R/hazard_estimation.R
+++ b/R/hazard_estimation.R
@@ -1,0 +1,45 @@
+estimate_hazard <- function(object, newdata, ci = FALSE, plot = FALSE, ...) {
+    # For hazardPlot, we only want one row in newdata
+    if (nrow(newdata) > 1 && plot) {
+        newdata <- newdata[1, , drop = FALSE]
+        warning("More than 1 row supplied to 'newdata'. Only the first row will be used.")
+    }
+    UseMethod("estimate_hazard")
+}
+
+estimate_hazard_default <- function(object, newdata, ci, plot, ...) {
+    stop("This function should be used with an object of class glm, cv.glmnet, gbm",
+         call. = TRUE)
+}
+
+estimate_hazard.glm <- function(object, newdata, ci, plot, ...) {
+    withCallingHandlers(pred <- predict(object, newdata, type = "link"),
+                        warning = handler_bsplines)
+    return(pred)
+}
+
+estimate_hazard.cv.glmnet <- function(object, newdata, ci, plot,
+                                   s = c("lambda.1se","lambda.min"), ...) {
+    if (is.numeric(s))
+        s <- s[1]
+    else if (is.character(s)) {
+        s <- match.arg(s)
+    }
+    if (!inherits(newdata, "matrix")) {
+        # Remove the intercept to get the right design matrix
+        formula_pred <- update(formula(delete.response(terms(object$formula))), ~ . -1)
+        newdata_matrix <- model.matrix(formula_pred, newdata)
+    } else {
+        newdata_matrix <- newdata
+    }
+    pred <- predict(object, newdata_matrix, s, newoffset = 0)
+
+    return(pred)
+}
+
+estimate_hazard.gbm <- function(object, newdata, ci, plot, n.trees, ...) {
+    withCallingHandlers(pred <- predict(object, newdata, type = "link",
+                                        n.trees, ...),
+                        warning = handler_offset)
+    return(pred)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -258,3 +258,11 @@ expand_dot_formula <- function(formula, data = NULL) {
     formula
 }
 
+# Streamlined version of pracma::cumtrapz
+trap_int <- function(x, y) {
+    x <- as.matrix(c(x))
+    m <- length(x)
+    y <- as.matrix(y)
+    ct <- apply(diff(x)/2 * (y[1:(m - 1), ] + y[2:m, ]), 2, cumsum)
+    return(rbind(0, ct))
+}

--- a/man/absoluteRisk.Rd
+++ b/man/absoluteRisk.Rd
@@ -67,63 +67,70 @@ absoluteRisk(object, ...)
 \arguments{
 \item{object}{Output of function \code{\link{fitSmoothHazard}}.}
 
-\item{time}{A vector of time points at which we should compute the absolute risks.}
+\item{time}{A vector of time points at which we should compute the absolute
+risks.}
 
-\item{newdata}{Optionally, a data frame in which to look for variables with which to predict. If
-omitted, the mean absolute risk is returned.}
+\item{newdata}{Optionally, a data frame in which to look for variables with
+which to predict. If omitted, the mean absolute risk is returned.}
 
-\item{method}{Method used for integration. Defaults to \code{"montecarlo"}, which implements
-Monte-Carlo integration. The only other option is \code{"numerical"}, which simply calls the
-function \code{\link{integrate}}.}
+\item{method}{Method used for integration. Defaults to \code{"numerical"},
+which uses the trapezoidal rule to integrate over all time points together.
+The only other option is \code{"montecarlo"}, which implements Monte-Carlo
+integration.}
 
-\item{nsamp}{Maximal number of subdivisions (if \code{method = "numerical"}) or number of sampled
-points (if \code{method = "montecarlo"}).}
+\item{nsamp}{Maximal number of subdivisions (if \code{method = "numerical"})
+or number of sampled points (if \code{method = "montecarlo"}).}
 
-\item{onlyMain}{Logical. For competing risks, should we return absolute risks only for the main
-event of interest? Defaults to \code{TRUE}.}
+\item{onlyMain}{Logical. For competing risks, should we return absolute risks
+only for the main event of interest? Defaults to \code{TRUE}.}
 
 \item{...}{Extra parameters. Currently these are simply ignored.}
 
-\item{s}{Value of the penalty parameter lambda at which predictions are required (for class
-\code{cv.glmnet}).}
+\item{s}{Value of the penalty parameter lambda at which predictions are
+required (for class \code{cv.glmnet}).}
 
 \item{n.trees}{Number of trees used in the prediction (for class \code{gbm}).}
 }
 \value{
-If \code{time} was provided, returns the estimated absolute risk for the user-supplied
-covariate profiles. This will be stored in a 2- or 3-dimensional array, depending on the input
-(see details). If both \code{time} and \code{newdata} were provided, returns the original data
+If \code{time} was provided, returns the estimated absolute risk for
+the user-supplied covariate profiles. This will be stored in a 2- or
+3-dimensional array, depending on the input (see details). If both
+\code{time} and \code{newdata} were provided, returns the original data
 with a new column containing the risk estimate at failure time.
 }
 \description{
-Using the output of the function \code{fitSmoothHazard}, we can compute absolute risks by
-integrating the fitted hazard function over a time period and then converting this to an
-estimated survival for each individual.
+Using the output of the function \code{fitSmoothHazard}, we can compute
+absolute risks by integrating the fitted hazard function over a time period
+and then converting this to an estimated survival for each individual.
 }
 \details{
-If the user supplies the original dataset through the parameter \code{newdata}, the mean absolute
-risk can be computed as the average of the output vector.
+If the user supplies the original dataset through the parameter
+\code{newdata}, the mean absolute risk can be computed as the average of the
+output vector.
 
-In general, if \code{time} is a vector of length greater than one, the output will include a
-column corresponding to the provided time points. Some modifications of the \code{time} vector
-are done: \code{time=0} is added, the time points are ordered, and duplicates are removed. All
-these modifications simplify the computations and give an output that can easily be used to plot
+In general, if \code{time} is a vector of length greater than one, the output
+will include a column corresponding to the provided time points. Some
+modifications of the \code{time} vector are done: \code{time=0} is added, the
+time points are ordered, and duplicates are removed. All these modifications
+simplify the computations and give an output that can easily be used to plot
 risk curves.
 
-On the other hand, if \code{time} corresponds to a single time point, the output does not include
-a column corresponding to time.
+On the other hand, if \code{time} corresponds to a single time point, the
+output does not include a column corresponding to time.
 
-If there is no competing risk, the output is a matrix where each column corresponds to the
-several covariate profiles, and where each row corresponds to a time point. If there are
-competing risks, the output will be a 3-dimensional array, with the third dimension corresponding
-to the different events.
+If there is no competing risk, the output is a matrix where each column
+corresponds to the several covariate profiles, and where each row corresponds
+to a time point. If there are competing risks, the output will be a
+3-dimensional array, with the third dimension corresponding to the different
+events.
 
-The numerical method should be good enough in most situation, but Monte Carlo integration can
-give more accurate results when the estimated hazard function is not smooth (e.g. when modeling
-with time-varying covariates). However, if there are competing risks, we strongly encourage the
-user to select Monte-Carlo integration, which is much faster than the numerical method. (This is
-due to the current implementation of the numerical method, and it may be improved in future
-versions.)
+The numerical method should be good enough in most situation, but Monte Carlo
+integration can give more accurate results when the estimated hazard function
+is not smooth (e.g. when modeling with time-varying covariates). However, if
+there are competing risks, we strongly encourage the user to select
+Monte-Carlo integration, which is much faster than the numerical method.
+(This is due to the current implementation of the numerical method, and it
+may be improved in future versions.)
 }
 \examples{
 # Simulate censored survival data for two outcome types from exponential distributions

--- a/tests/testthat/test-absRisk.R
+++ b/tests/testthat/test-absRisk.R
@@ -194,7 +194,7 @@ test_that("should compute risk when time and newdata aren't provided", {
     expect_true("risk" %in% names(absRiskDT))
 })
 
-# non-glm methods
+# non-glm methods----
 fitDF_gam <- fitSmoothHazard(event ~ s(ftime) + Z, data = DF, time = "ftime", family = "gam", ratio = 10)
 fitDT_gam <- fitSmoothHazard(event ~ s(ftime) + Z, data = DT, time = "ftime", family = "gam", ratio = 10)
 
@@ -216,9 +216,17 @@ test_that("no error in fitting gbm", {
                  silent = TRUE)
     riskDT <- try(absoluteRisk(fitDT_gbm, time = 0.5, newdata = newDT, n.trees = 100, nsamp = 500),
                  silent = TRUE)
+    riskDF_mc <- try(absoluteRisk(fitDF_gbm, time = 0.5, newdata = newDF, n.trees = 100, nsamp = 10,
+                                  method = "montecarlo"),
+                     silent = TRUE)
+    riskDT_mc <- try(absoluteRisk(fitDT_gbm, time = 0.5, newdata = newDT, n.trees = 100, nsamp = 10,
+                                  method = "montecarlo"),
+                     silent = TRUE)
 
     expect_false(inherits(riskDF, "try-error"))
     expect_false(inherits(riskDT, "try-error"))
+    expect_false(inherits(riskDF_mc, "try-error"))
+    expect_false(inherits(riskDT_mc, "try-error"))
 })
 
 extra_vars <- matrix(rnorm(10 * n), ncol = 10)
@@ -240,9 +248,17 @@ test_that("no error in fitting glmnet", {
                   silent = TRUE)
     riskDT <- try(absoluteRisk(fitDT_glmnet, time = 0.5, newdata = newDT_ext),
                   silent = TRUE)
+    riskDF_mc <- try(absoluteRisk(fitDF_glmnet, time = 0.5, newdata = newDF_ext, nsamp = 10,
+                                  method = "montecarlo"),
+                     silent = TRUE)
+    riskDT_mc <- try(absoluteRisk(fitDT_glmnet, time = 0.5, newdata = newDT_ext, nsamp = 10,
+                                  method = "montecarlo"),
+                     silent = TRUE)
 
     expect_false(inherits(riskDF, "try-error"))
     expect_false(inherits(riskDT, "try-error"))
+    expect_false(inherits(riskDF_mc, "try-error"))
+    expect_false(inherits(riskDT_mc, "try-error"))
 })
 
 test_that("no error in using custom lambda in glmnet", {

--- a/tests/testthat/test-glmnet.R
+++ b/tests/testthat/test-glmnet.R
@@ -83,6 +83,11 @@ risk_log <- try(absoluteRisk(fit_glmnet_log, time = 1,
                              newdata = new_x, nsamp = 100),
                 silent = TRUE)
 
+test_that("error with glm.fit",{
+    expect_error(absoluteRisk(fit_glm, time = 1,
+                              newdata = new_x, nsamp = 100))
+})
+
 test_that("no error in absoluteRisk with glmnet", {
 
     expect_false(inherits(risk, "try-error"))

--- a/tests/testthat/test-glmnet.R
+++ b/tests/testthat/test-glmnet.R
@@ -1,4 +1,4 @@
-context("Glmnet")
+context("Matrix interface")
 library(splines)
 
 N <- 1000; p <- 30
@@ -73,7 +73,8 @@ fit_glmnet_log <- fitSmoothHazard.fit(x, y, formula_time = ~ log(time),
                                       time = "time", event = "status",
                                       family = "glmnet", ratio = 10,
                                       lambda = c(0, 0.5))
-# Test absoluteRisk
+# Test absoluteRisk----
+# Only family="glmnet" has been implemented
 new_x <- x[1:10, ]
 risk <- try(absoluteRisk(fit_glmnet, time = 1,
                          newdata = new_x, nsamp = 100),
@@ -93,4 +94,25 @@ test_that("we get probabilities", {
     expect_true(all(risk <= 1))
     expect_true(all(risk_log >= 0))
     expect_true(all(risk_log <= 1))
+})
+
+# Test absoluteRisk--two time points
+risk <- try(absoluteRisk(fit_glmnet, time = c(1,2),
+                         newdata = new_x, nsamp = 100),
+            silent = TRUE)
+risk_log <- try(absoluteRisk(fit_glmnet_log, time = c(1,2),
+                             newdata = new_x, nsamp = 100),
+                silent = TRUE)
+
+test_that("no error in absoluteRisk with glmnet", {
+
+    expect_false(inherits(risk, "try-error"))
+    expect_false(inherits(risk_log, "try-error"))
+})
+
+test_that("we get probabilities", {
+    expect_true(all(risk[,-1] >= 0))
+    expect_true(all(risk[,-1] <= 1))
+    expect_true(all(risk_log[,-1] >= 0))
+    expect_true(all(risk_log[,-1] <= 1))
 })

--- a/tests/testthat/test-glmnet.R
+++ b/tests/testthat/test-glmnet.R
@@ -1,4 +1,5 @@
 context("Glmnet")
+library(splines)
 
 N <- 1000; p <- 30
 nzc <- p/3

--- a/tests/testthat/test-plotHazard.R
+++ b/tests/testthat/test-plotHazard.R
@@ -1,4 +1,7 @@
 context("plotHazard function")
+# Skip tests if in non-interactive session
+skip_if_not(interactive())
+
 library(splines)
 data("simdat")
 mod_glm <- casebase::fitSmoothHazard(status ~ trt + ns(log(eventtime), df = 3) +

--- a/tests/testthat/test-plotHazard.R
+++ b/tests/testthat/test-plotHazard.R
@@ -1,5 +1,5 @@
 context("plotHazard function")
-
+library(splines)
 data("simdat")
 mod_glm <- casebase::fitSmoothHazard(status ~ trt + ns(log(eventtime), df = 3) +
                                         trt:ns(log(eventtime),df=1),

--- a/tests/testthat/test-plotHazard.R
+++ b/tests/testthat/test-plotHazard.R
@@ -1,6 +1,6 @@
 context("plotHazard function")
-# Skip tests if in non-interactive session
-skip_if_not(interactive())
+# Uncomment next line to skip tests in non-interactive session
+# skip_if_not(interactive())
 
 library(splines)
 data("simdat")


### PR DESCRIPTION
This is my implementation of the trapezoidal rule to perform numerical integration. As discussed in #74 , this allows a big speed-up for `absoluteRisk`. I've updated the documentation to reflect this change, and I've added a few more tests. 

I've also cleaned up the code for regularized competing risk regression, which addresses #72 . In short, we now simply through an error if a user wants to get the absolute risk in this setting. I've kept the code but commented it out so that we can revisit as needed.

Fix #74 
Fix #72 