### PR TITLE
give warning when using gbm with nonlinear functions of time or interactions

### DIFF
--- a/R/fitting.R
+++ b/R/fitting.R
@@ -144,9 +144,9 @@ fitSmoothHazard <- function(formula, data, time,
             warning(paste(sprintf("You may be using a nonlinear function of %s.", timeVar),
                           "gbm may throw an error.", collapse = "\n"), call. = FALSE)
         }
-        if(detect_interaction_time(formula, timeVar)) {
-            warning(paste(sprintf("You may be using an interaction term with %s.", timeVar),
-                          "gbm may throw an error.", collapse = "\n"), call. = FALSE)
+        if(detect_interaction(formula)) {
+            warning("gbm may throw an error when using interaction terms",
+                    call. = FALSE)
         }
     }
 
@@ -249,9 +249,9 @@ fitSmoothHazard.fit <- function(x, y, formula_time, time, event, family = c("glm
             warning(paste(sprintf("You may be using a nonlinear function of %s.", timeVar),
                           "gbm may throw an error.", collapse = "\n"), call. = FALSE)
         }
-        if(detect_interaction_time(formula_time, timeVar)) {
-            warning(paste(sprintf("You may be using an interaction term with %s.", timeVar),
-                          "gbm may throw an error.", collapse = "\n"), call. = FALSE)
+        if(detect_interaction(formula_time)) {
+            warning("gbm may throw an error when using interaction terms",
+                    call. = FALSE)
         }
     }
 

--- a/R/fitting.R
+++ b/R/fitting.R
@@ -137,6 +137,19 @@ fitSmoothHazard <- function(formula, data, time,
         formula <- update(formula, ~ . + offset(offset))
     }
 
+    # gbm doesn't play nice with interactions and functions of time
+    if (family == "gbm") {
+        # So warn the user
+        if(detect_nonlinear_time(formula, timeVar)) {
+            warning(paste(sprintf("You may be using a nonlinear function of %s.", timeVar),
+                          "gbm may throw an error.", collapse = "\n"), call. = FALSE)
+        }
+        if(detect_interaction_time(formula, timeVar)) {
+            warning(paste(sprintf("You may be using an interaction term with %s.", timeVar),
+                          "gbm may throw an error.", collapse = "\n"), call. = FALSE)
+        }
+    }
+
     # Fit a binomial model if there are no competing risks
     if (length(typeEvents) == 2) {
         fittingFunction <- switch(family,
@@ -228,6 +241,19 @@ fitSmoothHazard.fit <- function(x, y, formula_time, time, event, family = c("glm
         varNames <- checkArgsTimeEvent(data = as.data.frame(y), time = timeVar)
         eventVar <- varNames$event
     } else eventVar <- event
+
+    # gbm doesn't play nice with interactions and functions of time
+    if (family == "gbm") {
+        # So warn the user
+        if(detect_nonlinear_time(formula_time, timeVar)) {
+            warning(paste(sprintf("You may be using a nonlinear function of %s.", timeVar),
+                          "gbm may throw an error.", collapse = "\n"), call. = FALSE)
+        }
+        if(detect_interaction_time(formula_time, timeVar)) {
+            warning(paste(sprintf("You may be using an interaction term with %s.", timeVar),
+                          "gbm may throw an error.", collapse = "\n"), call. = FALSE)
+        }
+    }
 
     typeEvents <- sort(unique(y[,eventVar]))
     # Call sampleCaseBase

--- a/R/utils.R
+++ b/R/utils.R
@@ -279,12 +279,9 @@ detect_nonlinear_time <- function(formula, timeVar) {
     any(unlist(contain_time))
 }
 
-# Detect if formula contains a function of time or interaction----
-detect_interaction_time <- function(formula, timeVar) {
-    # Extract variables in RHS of formula
-    terms <- attr(terms(formula), "term.labels")
-    # Extract their order
+detect_interaction <- function(formula) {
+    # Extract the order of the terms
     orders <- attr(terms(formula), "order")
-    # Check if any timeVar appears in terms of order > 1
-    any(grepl(timeVar, terms) & (orders > 1))
+    # Check if terms of order > 1
+    any(orders > 1)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -257,3 +257,24 @@ trap_int <- function(x, y) {
     ct <- apply(diff(x)/2 * (y[1:(m - 1), ] + y[2:m, ]), 2, cumsum)
     return(rbind(0, ct))
 }
+
+# Detect if formula contains a function of time or interaction----
+detect_nonlinear_time <- function(formula, timeVar) {
+    # Regex: formulas of time will include parentheses
+    # around the variable name
+    pattern <- paste0("\\(\\s*", timeVar, "\\s*\\)")
+    # Extract variables in RHS of formula
+    terms <- attr(terms(formula), "term.labels")
+    # Check if any term contains the regex
+    any(grepl(pattern, terms))
+}
+
+# Detect if formula contains a function of time or interaction----
+detect_interaction_time <- function(formula, timeVar) {
+    # Extract variables in RHS of formula
+    terms <- attr(terms(formula), "term.labels")
+    # Extract their order
+    orders <- attr(terms(formula), "order")
+    # Check if any timeVar appears in terms of order > 1
+    any(grepl(timeVar, terms) & (orders > 1))
+}

--- a/tests/testthat/test-fitting.R
+++ b/tests/testthat/test-fitting.R
@@ -88,3 +88,32 @@ test_that("sampling first and then fitting", {
 
     expect_false(inherits(model, "try-error"))
 })
+
+##################
+form <- formula(event ~ exposure + time)
+form_bs <- formula(event ~ exposure + bs(time))
+form_log <- formula(event ~ exposure + log(time))
+form_int <- formula(event ~ exposure*time)
+
+test_that("detecting non-linear functions of time", {
+    expect_false(detect_nonlinear_time(form, "time"))
+    expect_true(detect_nonlinear_time(form_bs, "time"))
+    expect_true(detect_nonlinear_time(form_log, "time"))
+    expect_false(detect_nonlinear_time(form_int, "time"))
+})
+
+test_that("detecting interactions with time", {
+    expect_false(detect_interaction_time(form, "time"))
+    expect_false(detect_interaction_time(form_bs, "time"))
+    expect_false(detect_interaction_time(form_log, "time"))
+    expect_true(detect_interaction_time(form_int, "time"))
+})
+
+test_that("warnings when using gbm witn non-linear functions of time or interactions", {
+    expect_warning(fitSmoothHazard(event ~ log(ftime) + Z,
+                                   data = DF, time = "ftime", family = "gbm"),
+                   regexp = "gbm may throw an error")
+    expect_warning(fitSmoothHazard(event ~ ftime*Z,
+                                   data = DF, time = "ftime", family = "gbm"),
+                   regexp = "gbm may throw an error")
+})

--- a/tests/testthat/test-fitting.R
+++ b/tests/testthat/test-fitting.R
@@ -129,10 +129,10 @@ test_that("Making sure we don't pick up anything that looks like time", {
 })
 
 test_that("detecting interactions with time", {
-    expect_false(detect_interaction_time(form, "time"))
-    expect_false(detect_interaction_time(form_bs, "time"))
-    expect_false(detect_interaction_time(form_log, "time"))
-    expect_true(detect_interaction_time(form_int, "time"))
+    expect_false(detect_interaction(form))
+    expect_false(detect_interaction(form_bs))
+    expect_false(detect_interaction(form_log))
+    expect_true(detect_interaction(form_int))
 })
 
 test_that("warnings when using gbm witn non-linear functions of time or interactions", {

--- a/tests/testthat/test-fitting.R
+++ b/tests/testthat/test-fitting.R
@@ -95,11 +95,37 @@ form_bs <- formula(event ~ exposure + bs(time))
 form_log <- formula(event ~ exposure + log(time))
 form_int <- formula(event ~ exposure*time)
 
+form_bs_extra <- formula(event ~ exposure + bs(time, df = 3))
+form_bs_named <- formula(event ~ exposure + bs(x = time))
+
 test_that("detecting non-linear functions of time", {
     expect_false(detect_nonlinear_time(form, "time"))
     expect_true(detect_nonlinear_time(form_bs, "time"))
     expect_true(detect_nonlinear_time(form_log, "time"))
     expect_false(detect_nonlinear_time(form_int, "time"))
+    expect_true(detect_nonlinear_time(form_bs_extra, "time"))
+    expect_true(detect_nonlinear_time(form_bs_named, "time"))
+})
+
+wrong <- formula(event ~ exposure + time + wrongtime)
+wrong_bs <- formula(event ~ exposure + time + bs(wrongtime))
+wrong_log <- formula(event ~ exposure + time + log(wrongtime))
+wrong_int <- formula(event ~ exposure*wrongtime + time)
+
+wrong2 <- formula(event ~ exposure + time + timewrong)
+wrong2_bs <- formula(event ~ exposure + time + bs(timewrong))
+wrong2_log <- formula(event ~ exposure + time + log(timewrong))
+wrong2_int <- formula(event ~ exposure*timewrong + time)
+
+test_that("Making sure we don't pick up anything that looks like time", {
+    expect_false(detect_nonlinear_time(wrong, "time"))
+    expect_false(detect_nonlinear_time(wrong_bs, "time"))
+    expect_false(detect_nonlinear_time(wrong_log, "time"))
+    expect_false(detect_nonlinear_time(wrong_int, "time"))
+    expect_false(detect_nonlinear_time(wrong2, "time"))
+    expect_false(detect_nonlinear_time(wrong2_bs, "time"))
+    expect_false(detect_nonlinear_time(wrong2_log, "time"))
+    expect_false(detect_nonlinear_time(wrong2_int, "time"))
 })
 
 test_that("detecting interactions with time", {

--- a/tests/testthat/test-glmnet.R
+++ b/tests/testthat/test-glmnet.R
@@ -39,10 +39,10 @@ test_that("no error in using nonlinear functions of time", {
                                           family = "glmnet", ratio = 10,
                                           lambda = c(0, 0.5)),
                       silent = TRUE)
-    fit_gbm <- try(fitSmoothHazard.fit(x, y, formula_time = ~ log(time),
-                                       time = "time", event = "status",
-                                       family = "gbm", ratio = 10),
-                   silent = TRUE)
+    # fit_gbm <- try(fitSmoothHazard.fit(x, y, formula_time = ~ log(time),
+    #                                    time = "time", event = "status",
+    #                                    family = "gbm", ratio = 10),
+    #                silent = TRUE)
 
     fit_glm_splines <- try(fitSmoothHazard.fit(x, y, formula_time = ~ bs(time),
                                                time = "time", event = "status", ratio = 10),
@@ -52,18 +52,29 @@ test_that("no error in using nonlinear functions of time", {
                                                   family = "glmnet", ratio = 10,
                                                   lambda = c(0, 0.5)),
                               silent = TRUE)
-    fit_gbm_splines <- try(fitSmoothHazard.fit(x, y, formula_time = ~ bs(time),
-                                               time = "time", event = "status",
-                                               family = "gbm", ratio = 10),
-                           silent = TRUE)
+    # fit_gbm_splines <- try(fitSmoothHazard.fit(x, y, formula_time = ~ bs(time),
+    #                                            time = "time", event = "status",
+    #                                            family = "gbm", ratio = 10),
+    #                        silent = TRUE)
 
     expect_false(inherits(fit_glm, "try-error"))
     expect_false(inherits(fit_glmnet, "try-error"))
-    expect_false(inherits(fit_gbm, "try-error"))
+    # expect_false(inherits(fit_gbm, "try-error"))
 
     expect_false(inherits(fit_glm_splines, "try-error"))
     expect_false(inherits(fit_glmnet_splines, "try-error"))
-    expect_false(inherits(fit_gbm_splines, "try-error"))
+    # expect_false(inherits(fit_gbm_splines, "try-error"))
+})
+
+test_that("warnings when using gbm witn non-linear functions of time or interactions", {
+    expect_warning(fitSmoothHazard.fit(x, y, formula_time = ~ log(time),
+                                       time = "time", event = "status",
+                                       family = "gbm", ratio = 10),
+                   regexp = "gbm may throw an error")
+    expect_warning(fitSmoothHazard.fit(x, y, formula_time = ~ bs(time),
+                                       time = "time", event = "status",
+                                       family = "gbm", ratio = 10),
+                   regexp = "gbm may throw an error")
 })
 
 fit_glmnet <- fitSmoothHazard.fit(x, y, time = "time", event = "status",

--- a/tests/testthat/test-plotHazard.R
+++ b/tests/testthat/test-plotHazard.R
@@ -25,7 +25,7 @@ mod_glmnet <- casebase::fitSmoothHazard(status ~ trt + ns(log(eventtime), df = 3
                                     ratio = 10,
                                     family = "glmnet")
 
-mod_gbm <- casebase::fitSmoothHazard(status ~ trt + log(eventtime),
+mod_gbm <- casebase::fitSmoothHazard(status ~ trt + eventtime,
                                      time = "eventtime",
                                      interaction.depth = 2,
                                      data = simdat,


### PR DESCRIPTION
This issue has been opened for a little while now, so I though I would look at it. I don't know if I've completely solved the issue. What I did is that now anytime we use `family = "gbm"` with nonlinear functions of time or interactions in `formula`, `fitSmoothHazard` will give a warning that `gbm` may throw an error. 

I don't know if that's quite enough @sahirbhatnagar . Let me know what you think.

Also, note that in my RStudio environment, when I run the code in Issue #65 I still get an error on top of the warning, but I don't actually see the warning message (it's blocked by the box that allows me to see the traceback or rerun with debug). I think that's a bug in RStudio, because when I run it in the console, I can see both the error message and the warning.

fixes #65 