### PR TITLE
reset offset and add class

### DIFF
--- a/R/fitting.R
+++ b/R/fitting.R
@@ -175,6 +175,11 @@ fitSmoothHazard <- function(formula, data, time,
     out$timeVar <- timeVar
     out$eventVar <- eventVar
     if (family == "glmnet") out$formula <- formula
+    # Reset offset for absolute risk estimation, but keep track of it
+    out$offset <- out$data$offset
+    out$data$offset <- 0
+    # Add new class
+    class(out) <- c("singleEventCB", class(out))
   } else {
     # Otherwise fit a multinomial regression
     if (!family %in% c("glm", "glmnet")) {
@@ -304,7 +309,7 @@ fitSmoothHazard.fit <- function(x, y, formula_time, time, event, family = c("glm
       censored.indicator, ratio
     )
   }
-  # Format everything into matrices and expend variables that need to be expended
+  # Format everything into matrices and expand variables that need to be expanded
   sample_event <- as.matrix(sampleData[, eventVar])
   sample_time <- if (family %in% c("glmnet", "gbm")) {
     model.matrix(
@@ -344,6 +349,9 @@ fitSmoothHazard.fit <- function(x, y, formula_time, time, event, family = c("glm
     out$eventVar <- eventVar
     out$matrix.fit <- TRUE
     out$formula_time <- formula_time
+    out$offset <- sample_offset
+    # Add new class
+    class(out) <- c("singleEventCB", class(out))
   } else {
     if (family == "glm") stop("The matrix interface is not available for glm and competing risks")
     if (family != "glmnet") stop("Not implemented yet")

--- a/R/hazardPlot.R
+++ b/R/hazardPlot.R
@@ -97,15 +97,15 @@ hazardPlot <- function(object, newdata, type = c("hazard"), xlab = NULL,
     if (any(names(newdata) %in% object[["timeVar"]]))
         stop("%s cannot be used as a colunm name in newdata. remove it.",object[["timeVar"]])
 
-    obj_class <- class(object)[1]
+    obj_class <- class(object)[2]
 
-    if (obj_class %ni%  c("glm", "gam", "gbm", "cv.glmnet"))
+    if (!inherits(object, c("glm", "gam", "gbm", "cv.glmnet")))
         stop("object must be of class glm, gam, gbm or cv.glmnet")
 
     if (ci) {
         if (!between(ci.lvl, 0,1, incbounds = FALSE))
             stop("ci.lvl must be between 0 and 1")
-        if (obj_class %ni% c("glm","gam")) {
+        if (!inherits(object, c("glm", "gam"))) {
             warning(sprintf("Confidence intervals cannot be calculated for objects of class %s.",obj_class))
             ci <- FALSE
         }
@@ -127,7 +127,7 @@ hazardPlot <- function(object, newdata, type = c("hazard"), xlab = NULL,
     newdata$offset <- 0
     # If gbm was fitted with an offset, predict.gbm ignores it but still gives a warning
     # The following line silences this warning
-    if (obj_class == "gbm") attr(object$Terms, "offset") <- NULL
+    if (!inherits(object, "gbm")) attr(object$Terms, "offset") <- NULL
 
     preds <- switch (obj_class,
                      glm = {
@@ -162,6 +162,9 @@ hazardPlot <- function(object, newdata, type = c("hazard"), xlab = NULL,
                      },
 
                      gbm = {
+                         # If gbm was fitted with an offset, predict.gbm ignores it but still gives a warning
+                         # The following line silences this warning
+                         attr(object$Terms, "offset") <- NULL
                          pp <- predict(object, newdata, n.trees = object$n.trees)
                          newdata$predictedloghazard <- pp
                          pp


### PR DESCRIPTION
This small pull request does two things:

- It resets the offset to zero after fitting
- It adds the class `singleEventCB`to the object we fitted.

The second change broke `hazardPlot` (which we're updating anyway): it was looking at the first element of the vector `class(object)` to know what kind of object it was. I updated the code to use `inherits`, which is better practice and safer anyway.

Closes #100 