### PR TITLE
detect nested nonlinear functions of time

### DIFF
--- a/tests/testthat/test-fitting.R
+++ b/tests/testthat/test-fitting.R
@@ -50,6 +50,7 @@ form <- formula(event ~ exposure + time)
 form_bs <- formula(event ~ exposure + bs(time))
 form_log <- formula(event ~ exposure + log(time))
 form_int <- formula(event ~ exposure*time)
+form_nested <- formula(cens ~ horTh*nsx(log(time), df = 3) + age*time)
 
 form_bs_extra <- formula(event ~ exposure + bs(time, df = 3))
 form_bs_named <- formula(event ~ exposure + bs(x = time))
@@ -59,6 +60,8 @@ test_that("detecting non-linear functions of time", {
     expect_true(detect_nonlinear_time(form_bs, "time"))
     expect_true(detect_nonlinear_time(form_log, "time"))
     expect_false(detect_nonlinear_time(form_int, "time"))
+    expect_true(detect_nonlinear_time(form_nested, "time"))
+
     expect_true(detect_nonlinear_time(form_bs_extra, "time"))
     expect_true(detect_nonlinear_time(form_bs_named, "time"))
 })


### PR DESCRIPTION
This addresses the issue with `detect_nonlinear_time` and nested functions of time (e.g. splines on `log(time)`). The solution I provide is to rerun the regex matching logic on its output (i.e. if the function arguments call a function, then extract its arguments, etc.). This ensures that we get the correct output whenever:

- nonlinear functions are nested;

- some of these nonlinear functions have extra arguments.

I also added a new test based on the original bug.

Fix #111 

