### PR TITLE
Issue119

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: casebase
 Type: Package
 Title: Fitting Flexible Smooth-in-Time Hazards and Risk Functions via Logistic and Multinomial Regression
-Version: 0.2.1.9001
-Date: 2019-8-1
+Version: 1.0.0.9000
+Date: 2020-06-23
 Authors@R: c(
   person("Sahir", "Bhatnagar", email = "sahir.bhatnagar@gmail.com",
   role = c("aut", "cre"), comment = "http://sahirbhatnagar.com/"),
@@ -23,7 +23,7 @@ Description: Implements the case-base sampling approach of Hanley and Miettinen 
     and covariates, and readily allows for non-proportionality. We also provide a plot method for visualizing 
     incidence density via population time plots.
 Depends:
-    R (>= 3.3.0)
+    R (>= 3.5.0)
 Imports:
     data.table,
     ggplot2,

--- a/R/absoluteRisk-cr.R
+++ b/R/absoluteRisk-cr.R
@@ -1,7 +1,9 @@
 #' @rdname absoluteRisk
 #' @export
-absoluteRisk.CompRisk <- function(object, time, newdata, method = c("numerical", "montecarlo"),
-                                  nsamp = 100, onlyMain = TRUE, type = c("CI", "survival"),
+absoluteRisk.CompRisk <- function(object, time, newdata,
+                                  method = c("numerical", "montecarlo"),
+                                  nsamp = 100, onlyMain = TRUE,
+                                  type = c("CI", "survival"),
                                   addZero = TRUE) {
     method <- match.arg(method)
     type <- match.arg(type)
@@ -9,7 +11,8 @@ absoluteRisk.CompRisk <- function(object, time, newdata, method = c("numerical",
     if (missing(newdata)) {
         # Should we use the whole case-base dataset or the original one?
         if (is.null(object@originalData)) {
-            stop("Cannot estimate the mean absolute risk without the original data. See documentation.",
+            stop(paste("Cannot estimate the mean absolute risk without",
+                       "the original data. See documentation."),
                  call. = FALSE)
         }
         newdata <- object@originalData
@@ -159,20 +162,27 @@ absoluteRisk.CompRisk <- function(object, time, newdata, method = c("numerical",
     }
     # Sometimes montecarlo integration gives nonsensical probability estimates
     if (method == "montecarlo" && (any(output < 0) | any(output > 1))) {
-        warning("Some probabilities are out of range. Consider increasing nsamp or using numerical integration", call. = FALSE)
+        warning(paste("Some probabilities are out of range. Consider",
+                      "increasing nsamp or using numerical integration"),
+                call. = FALSE)
     }
+    attr(output, "type") <- type
     return(output)
 
 }
 
 # #' @rdname absoluteRisk
 # #' @export
-absoluteRisk.CompRiskGlmnet <- function(object, time, newdata, method = c("numerical", "montecarlo"),
-                                        nsamp = 100, onlyMain = TRUE, s = c("lambda.1se","lambda.min"),
-                                        type = c("CI", "survival"), addZero = TRUE, ...) {
+absoluteRisk.CompRiskGlmnet <- function(object, time, newdata,
+                                        method = c("numerical", "montecarlo"),
+                                        nsamp = 100, onlyMain = TRUE,
+                                        s = c("lambda.1se","lambda.min"),
+                                        type = c("CI", "survival"),
+                                        addZero = TRUE, ...) {
     # The current implementation doesn't work
     stop(paste("object is of class", class(object),
-               "\nabsoluteRisk should be used with an object of class glm, cv.glmnet, gbm, or CompRisk"),
+               "\nabsoluteRisk should be used with an object of class glm,",
+               "cv.glmnet, gbm, or CompRisk"),
          call. = TRUE)
     # We're keeping the code and hope to get back to it soon----
     ############################

--- a/R/absoluteRisk-cr.R
+++ b/R/absoluteRisk-cr.R
@@ -129,36 +129,18 @@ absoluteRisk.CompRisk <- function(object, time, newdata,
     if (onlyMain) {
         # Switch to survival scale?
         if (type == "survival") {
-            output[,-1,] <- 1 - output[,-1,]
+            output[, -1] <- 1 - output[, -1, drop = FALSE]
         }
-
-        # Reformat output when only one time point
-        if (length(time) == 1) {
-            if (time == 0) {
-                output <- output[1,-1,drop = FALSE]
-            } else {
-                output <- output[2,-1,drop = FALSE]
-            }
-            dimnames(output)[[1]] <- as.character(time)
-        } else {
-            if (!addZero) output <- output[-1,,drop = FALSE]
-        }
+        # Add time = 0?
+        if (!addZero) output <- output[-1, , drop = FALSE]
     } else {
         # Switch to survival scale?
         if (type == "survival") {
-            output[,-1,] <- 1 - output[,-1,]
+            output[,-1,] <- 1 - output[, -1, ]
         }
-        # Reformat output when only one time point
-        if (length(time) == 1) {
-            if (time == 0) {
-                output <- output[1,-1,,drop = FALSE]
-            } else {
-                output <- output[2,-1,,drop = FALSE]
-            }
-            dimnames(output)[[1]] <- as.character(time)
-        } else {
-            if (!addZero) output <- output[-1,,,drop = FALSE]
-        }
+        # Add time = 0?
+        if (!addZero) output <- output[-1, , , drop = FALSE]
+
     }
     # Sometimes montecarlo integration gives nonsensical probability estimates
     if (method == "montecarlo" && (any(output < 0) | any(output > 1))) {

--- a/R/absoluteRisk.R
+++ b/R/absoluteRisk.R
@@ -68,7 +68,7 @@
 #' @export
 #' @importFrom stats formula delete.response setNames
 #' @examples
-#' # Simulate censored survival data for two outcome types from exponential distributions
+#' # Simulate censored survival data for two outcome types
 #' library(data.table)
 #' set.seed(12345)
 #' nobs <- 1000
@@ -81,7 +81,7 @@
 #' # event type 0-censored, 1-event of interest, 2-competing event
 #' # t observed time/endpoint
 #' # z is a binary covariate
-#' DT <- data.table(z=rbinom(nobs, 1, 0.5))
+#' DT <- data.table(z = rbinom(nobs, 1, 0.5))
 #' DT[,`:=` ("t_event" = rweibull(nobs, 1, b1),
 #'           "t_comp" = rweibull(nobs, 1, b2))]
 #' DT[,`:=`("event" = 1 * (t_event < t_comp) + 2 * (t_event >= t_comp),
@@ -90,14 +90,18 @@
 #'
 #' out_linear <- fitSmoothHazard(event ~ time + z, DT, ratio = 10)
 #'
-#' linear_risk <- absoluteRisk(out_linear, time = 10, newdata = data.table("z"=c(0,1)))
-absoluteRisk <- function(object, time, newdata, method = c("numerical", "montecarlo"),
-                         nsamp = 100, s = c("lambda.1se","lambda.min"),
-                         n.trees, onlyMain = TRUE, type = c("CI", "survival"),
+#' linear_risk <- absoluteRisk(out_linear, time = 10,
+#'                             newdata = data.table("z" = c(0,1)))
+absoluteRisk <- function(object, time, newdata,
+                         method = c("numerical", "montecarlo"),
+                         nsamp = 100, s = c("lambda.1se", "lambda.min"),
+                         n.trees, onlyMain = TRUE,
+                         type = c("CI", "survival"),
                          addZero = TRUE, ntimes = 100, ...) {
     if (!inherits(object, c("glm", "cv.glmnet", "gbm", "CompRisk"))) {
         stop(paste("object is of class", class(object)[1],
-                   "\nabsoluteRisk should be used with an object of class glm, cv.glmnet, gbm, or CompRisk"),
+                   "\nabsoluteRisk should be used with an object of class glm,",
+                   "cv.glmnet, gbm, or CompRisk"),
              call. = TRUE)
     }
     if (inherits(object, "CompRisk")) {
@@ -111,12 +115,15 @@ absoluteRisk <- function(object, time, newdata, method = c("numerical", "monteca
     type <- match.arg(type)
     if (is.numeric(s)) {
         s <- s[1]
-        if (length(s) > 1) warning("More than one value for s has been supplied. Only first entry will be used")
+        if (length(s) > 1) {
+            warning(paste("More than one value for s has been",
+                          "supplied. Only first entry will be used"))
+            }
     } else if (is.character(s)) {
         s <- match.arg(s)
     }
     if (inherits(object, "gbm")) {
-        if(missing(n.trees)) stop("n.trees is missing")
+        if (missing(n.trees)) stop("n.trees is missing")
     } else n.trees <- NULL
     if (!missing(newdata) && is.character(newdata) && newdata == "typical") {
         newdata <- if (is.null(object$matrix.fit)) {
@@ -143,7 +150,7 @@ absoluteRisk <- function(object, time, newdata, method = c("numerical", "monteca
             # at equidistant points
             max_time <- if (is.null(object$matrix.fit)) {
                 max(object$originalData[object$timeVar][[1]])
-            } else max(object$originalData$y[,object$timeVar])
+            } else max(object$originalData$y[, object$timeVar])
             time <- seq(0, max_time, length.out = ntimes)
         }
         return(estimate_risk_newtime(object, time, newdata,
@@ -166,27 +173,28 @@ estimate_risk <- function(object, method, nsamp, s, n.trees, type, ...) {
     # compute risk at failure times
     time_vector <- if (is.null(object$matrix.fit)) {
         newdata[object$timeVar][[1]]
-        } else object$originalData$y[,object$timeVar]
+        } else object$originalData$y[, object$timeVar]
     # Create a vectorised hazard function
     if (inherits(object, "cv.glmnet") && !is.null(object$matrix.fit)) {
         hazard <- function(x, fit, newdata, s, n.trees, ...) {
             # Note: the offset should be set to zero when estimating the hazard.
-            # newdata_matrix <- cbind(x, newdata)
-            newdata_matrix <- newdata[,colnames(newdata) != fit$timeVar, drop = FALSE]
-            # newdata_matrix is organized to match the output from fitSmoothHazard.fit
-            newdata_matrix <- as.matrix(cbind(model.matrix(update(fit$formula_time, ~ . -1),
-                                                           setNames(data.frame(x), fit$timeVar)),
+            newdata_matrix <- newdata[,colnames(newdata) != fit$timeVar,
+                                      drop = FALSE]
+            # newdata_matrix matches output from fitSmoothHazard.fit
+            temp_matrix <- model.matrix(update(fit$formula_time, ~ . -1),
+                                        setNames(data.frame(x), fit$timeVar))
+            newdata_matrix <- as.matrix(cbind(temp_matrix,
                                               as.data.frame(newdata_matrix)))
 
-            pred <- estimate_hazard(fit, newdata_matrix, plot = FALSE, ci = FALSE,
-                                    s = s, n.trees = n.trees, ...)
+            pred <- estimate_hazard(fit, newdata_matrix, plot = FALSE,
+                                    ci = FALSE, s = s, n.trees = n.trees, ...)
             return(as.numeric(exp(pred)))
         }
     } else {
         hazard <- function(x, fit, newdata, s, n.trees, ...) {
             # Note: the offset should be set to zero when estimating the hazard.
             newdata2 <- data.frame(newdata)
-            newdata2 <- newdata2[rep(1, length(x)),]
+            newdata2 <- newdata2[rep(1, length(x)), ]
             newdata2[fit$timeVar] <- x
             pred <- estimate_hazard(fit, newdata2, plot = FALSE, ci = FALSE,
                                     s = s, n.trees = n.trees, ...)
@@ -203,9 +211,11 @@ estimate_risk <- function(object, method, nsamp, s, n.trees, type, ...) {
 
     # Format the output depending on type
     if (is.data.frame(newdata)) {
-        newdata[,riskVar] <- if(type == "CI") 1 - exp(-risk_res) else exp(-risk_res)
+        newdata[, riskVar] <- ifelse(type == "CI",
+                                    1 - exp(-risk_res),
+                                    exp(-risk_res))
     } else {
-        newdata <- if(type == "CI") {
+        newdata <- if (type == "CI") {
             cbind(1 - exp(-risk_res), newdata)
         } else cbind(exp(-risk_res), newdata)
         colnames(newdata)[1] <- riskVar
@@ -220,46 +230,47 @@ estimate_risk_newtime <- function(object, time, newdata, method, nsamp,
     if (missing(newdata)) {
         # Should we use the whole case-base dataset or the original one?
         if (is.null(object$originalData)) {
-            stop("Cannot estimate the mean absolute risk without the original data. See documentation.",
+            stop(paste("Cannot estimate the mean absolute risk without",
+                       "the original data. See documentation."),
                  call. = FALSE)
         }
         newdata <- object$originalData
-        # colnames(data)[colnames(data) == "event"] <- "status"
-        # Next commented line will break on data.table
-        # newdata <- newdata[, colnames(newdata) != "time"]
         unselectTime <- (names(newdata) != object$timeVar)
         newdata <- subset(newdata, select = unselectTime)
     }
     time_ordered <- unique(c(0, sort(time)))
     output <- matrix(NA, ncol = nrow(newdata) + 1, nrow = length(time_ordered))
-    output[,1] <- time_ordered
+    output[, 1] <- time_ordered
     colnames(output) <- c("time", rep("", nrow(newdata)))
     rownames(output) <- rep("", length(time_ordered))
-    output[1,-1] <- 0
+    output[1, -1] <- 0
 
     if (length(time_ordered) > 1) {
-        # output[1,-1] <- 0
         if (method == "numerical") {
             # Compute points at which we evaluate integral
-            # Note: there's probably a more efficient way of choosing the knots...
+            # Note: there's probably a more efficient way of choosing the knots
             knots <- seq(0, max(time_ordered),
                          length.out = (length(time_ordered) - 1) * nsamp)
             knots <- unique(sort(c(knots, time_ordered)))
-            for (j in 1:nrow(newdata)) {
+            for (j in seq_len(nrow(newdata))) {
                 # Extract current obs
                 current_obs <- newdata[j,,drop = FALSE]
                 # Use trapezoidal rule for integration----
                 if (inherits(newdata, "matrix")) {
-                    newdata2 <- current_obs[,colnames(newdata) != object$timeVar, drop = FALSE]
-                    # newdata2 is organized to match the output from fitSmoothHazard.fit
-                    newdata2 <- as.matrix(cbind(model.matrix(update(object$formula_time, ~ . -1),
-                                                                   setNames(data.frame(knots), object$timeVar)),
+                    newdata2 <- current_obs[,colnames(newdata) != object$timeVar,
+                                            drop = FALSE]
+                    # newdata2 matches the output from fitSmoothHazard.fit
+                    temp_matrix <- model.matrix(update(object$formula_time,
+                                                       ~ . -1),
+                                                setNames(data.frame(knots),
+                                                         object$timeVar))
+                    newdata2 <- as.matrix(cbind(temp_matrix,
                                                 as.data.frame(newdata2)))
                 } else {
                     # Create data.table for prediction
                     newdata2 <- data.table(current_obs)
                     newdata2 <- newdata2[rep(1, length(knots))]
-                    newdata2[,object$timeVar := knots]
+                    newdata2[, object$timeVar := knots]
                 }
                 pred <- estimate_hazard(object = object, newdata = newdata2,
                                         plot = FALSE, ci = FALSE,
@@ -268,7 +279,8 @@ estimate_risk_newtime <- function(object, time, newdata, method, nsamp,
                 # First remove infinite values (e.g. with log(t))
                 pred_exp <- exp(pred)
                 pred_exp[which(pred_exp %in% c(Inf, -Inf))] <- 0
-                output[,j + 1] <- trap_int(knots, pred_exp)[knots %in% c(0, time_ordered)]
+                which_knots <- knots %in% c(0, time_ordered)
+                output[, j + 1] <- trap_int(knots, pred_exp)[which_knots]
             }
 
         }
@@ -276,7 +288,7 @@ estimate_risk_newtime <- function(object, time, newdata, method, nsamp,
             # Sample points at which we evaluate function
             knots <- runif(n = length(time_ordered)* nsamp,
                            min = 0, max = max(time_ordered))
-            for (j in 1:nrow(newdata)) {
+            for (j in seq_len(nrow(newdata))) {
                 # Extract current obs
                 current_obs <- newdata[j,,drop = FALSE]
                 # Create data.table for prediction
@@ -289,7 +301,8 @@ estimate_risk_newtime <- function(object, time, newdata, method, nsamp,
                 # Compute integral using MC integration
                 pred_exp <- exp(pred)
                 pred_exp[which(pred_exp %in% c(Inf, -Inf))] <- NA
-                mean_values <- sapply(split(pred_exp, cut(knots, breaks = time_ordered)),
+                mean_values <- sapply(split(pred_exp,
+                                            cut(knots, breaks = time_ordered)),
                                       mean, na.rm = TRUE)
                 integral_estimates <- mean_values * diff(time_ordered)
                 output[,j + 1] <- cumsum(c(0, integral_estimates))
@@ -300,7 +313,8 @@ estimate_risk_newtime <- function(object, time, newdata, method, nsamp,
     }
     # Sometimes montecarlo integration gives nonsensical probability estimates
     if (method == "montecarlo" && (any(output[,-1] < 0) | any(output[,-1] > 1))) {
-        warning("Some probabilities are out of range. Consider increasing nsamp or using numerical integration",
+        warning(paste("Some probabilities are out of range. Consider",
+                      "increasing nsamp or using numerical integration"),
                 call. = FALSE)
     }
 

--- a/R/absoluteRisk.R
+++ b/R/absoluteRisk.R
@@ -6,24 +6,16 @@
 #' absolute risks by integrating the fitted hazard function over a time period
 #' and then converting this to an estimated survival for each individual.
 #'
-#' If the user supplies the original dataset through the parameter
-#' \code{newdata}, the mean absolute risk can be computed as the average of the
-#' output vector.
-#'
 #' If \code{newdata = "typical"}, we create a typical covariate profile for the
 #' absolute risk computation. This means that we take the median for numerical
 #' and date variables; we take the first element in alphabetical order for
 #' character variables; and we take the reference level for factor variables.
 #'
-#' In general, if \code{time} is a vector of length greater than one, the output
-#' will include a column corresponding to the provided time points. Some
-#' modifications of the \code{time} vector are done: \code{time=0} is added, the
-#' time points are ordered, and duplicates are removed. All these modifications
-#' simplify the computations and give an output that can easily be used to plot
-#' risk curves.
-#'
-#' On the other hand, if \code{time} corresponds to a single time point, the
-#' output does not include a column corresponding to time.
+#' In general, the output will include a column corresponding to the provided
+#' time points. Some modifications of the \code{time} vector are done:
+#' \code{time=0} is added, the time points are ordered, and duplicates are
+#' removed. All these modifications simplify the computations and give an output
+#' that can easily be used to plot risk curves.
 #'
 #' If there is no competing risk, the output is a matrix where each column
 #' corresponds to the several covariate profiles, and where each row corresponds
@@ -61,10 +53,10 @@
 #' @param ntimes Number of time points (only used if \code{time} is missing).
 #' @param ... Extra parameters. Currently these are simply ignored.
 #' @return If \code{time} was provided, returns the estimated absolute risk for
-#'   the user-supplied covariate profiles. This will be stored in a 2- or
-#'   3-dimensional array, depending on the input (see details). If both
-#'   \code{time} and \code{newdata} were provided, returns the original data
-#'   with a new column containing the risk estimate at failure time.
+#'   the user-supplied covariate profiles. This will be stored in a matrix or a
+#'   higher dimensional array, depending on the input (see details). If both
+#'   \code{time} and \code{newdata} are missing, returns the original data
+#'   with a new column containing the risk estimate at failure times.
 #' @export
 #' @importFrom stats formula delete.response setNames
 #' @examples
@@ -318,18 +310,8 @@ estimate_risk_newtime <- function(object, time, newdata, method, nsamp,
                       "increasing nsamp or using numerical integration"),
                 call. = FALSE)
     }
-
-    # Reformat output when only one time point
-    if (length(time) == 1) {
-        if (time == 0) {
-            output <- output[1,-1,drop = FALSE]
-        } else {
-            output <- output[2,-1,drop = FALSE]
-        }
-        rownames(output) <- time
-    } else {
-        if (!addZero) output <- output[-1,,drop = FALSE]
-    }
+    # Add time = 0?
+    if (!addZero) output <- output[-1, , drop = FALSE]
     # Add class
     class(output) <- c("absRiskCB", class(output))
     attr(output, "type") <- type

--- a/R/absoluteRisk.R
+++ b/R/absoluteRisk.R
@@ -220,6 +220,7 @@ estimate_risk <- function(object, method, nsamp, s, n.trees, type, ...) {
         } else cbind(exp(-risk_res), newdata)
         colnames(newdata)[1] <- riskVar
     }
+    attr(newdata, "type") <- type
     return(newdata)
 }
 
@@ -331,5 +332,6 @@ estimate_risk_newtime <- function(object, time, newdata, method, nsamp,
     }
     # Add class
     class(output) <- c("absRiskCB", class(output))
+    attr(output, "type") <- type
     return(output)
 }

--- a/R/methods.R
+++ b/R/methods.R
@@ -573,7 +573,7 @@ plot.singleEventCB <- function(x, ...,
       hazard.params
     ))
 
-    print(tt)
+    # print(tt)
 
     invisible(tt)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,4 @@
-.onAttach <- function(...){
-    # packageStartupMessage(manhattanlyWelcomeMessage())
-    packageStartupMessage("See example usage at http://sahirbhatnagar.com/casebase/")
+.onAttach <- function (...){
+    packageStartupMessage(paste("See example usage at",
+                                "http://sahirbhatnagar.com/casebase/"))
 }

--- a/man/absoluteRisk.Rd
+++ b/man/absoluteRisk.Rd
@@ -112,7 +112,7 @@ integration can give more accurate results when the estimated hazard function
 is not smooth (e.g. when modeling with time-varying covariates).
 }
 \examples{
-# Simulate censored survival data for two outcome types from exponential distributions
+# Simulate censored survival data for two outcome types
 library(data.table)
 set.seed(12345)
 nobs <- 1000
@@ -125,7 +125,7 @@ b2 <- 50
 # event type 0-censored, 1-event of interest, 2-competing event
 # t observed time/endpoint
 # z is a binary covariate
-DT <- data.table(z=rbinom(nobs, 1, 0.5))
+DT <- data.table(z = rbinom(nobs, 1, 0.5))
 DT[,`:=` ("t_event" = rweibull(nobs, 1, b1),
           "t_comp" = rweibull(nobs, 1, b2))]
 DT[,`:=`("event" = 1 * (t_event < t_comp) + 2 * (t_event >= t_comp),
@@ -134,5 +134,6 @@ DT[time >= tlim, `:=`("event" = 0, "time" = tlim)]
 
 out_linear <- fitSmoothHazard(event ~ time + z, DT, ratio = 10)
 
-linear_risk <- absoluteRisk(out_linear, time = 10, newdata = data.table("z"=c(0,1)))
+linear_risk <- absoluteRisk(out_linear, time = 10,
+                            newdata = data.table("z" = c(0,1)))
 }

--- a/man/absoluteRisk.Rd
+++ b/man/absoluteRisk.Rd
@@ -71,10 +71,10 @@ required (for class \code{cv.glmnet}).}
 }
 \value{
 If \code{time} was provided, returns the estimated absolute risk for
-the user-supplied covariate profiles. This will be stored in a 2- or
-3-dimensional array, depending on the input (see details). If both
-\code{time} and \code{newdata} were provided, returns the original data
-with a new column containing the risk estimate at failure time.
+the user-supplied covariate profiles. This will be stored in a matrix or a
+higher dimensional array, depending on the input (see details). If both
+\code{time} and \code{newdata} are missing, returns the original data
+with a new column containing the risk estimate at failure times.
 }
 \description{
 Using the output of the function \code{fitSmoothHazard}, we can compute
@@ -82,24 +82,16 @@ absolute risks by integrating the fitted hazard function over a time period
 and then converting this to an estimated survival for each individual.
 }
 \details{
-If the user supplies the original dataset through the parameter
-\code{newdata}, the mean absolute risk can be computed as the average of the
-output vector.
-
 If \code{newdata = "typical"}, we create a typical covariate profile for the
 absolute risk computation. This means that we take the median for numerical
 and date variables; we take the first element in alphabetical order for
 character variables; and we take the reference level for factor variables.
 
-In general, if \code{time} is a vector of length greater than one, the output
-will include a column corresponding to the provided time points. Some
-modifications of the \code{time} vector are done: \code{time=0} is added, the
-time points are ordered, and duplicates are removed. All these modifications
-simplify the computations and give an output that can easily be used to plot
-risk curves.
-
-On the other hand, if \code{time} corresponds to a single time point, the
-output does not include a column corresponding to time.
+In general, the output will include a column corresponding to the provided
+time points. Some modifications of the \code{time} vector are done:
+\code{time=0} is added, the time points are ordered, and duplicates are
+removed. All these modifications simplify the computations and give an output
+that can easily be used to plot risk curves.
 
 If there is no competing risk, the output is a matrix where each column
 corresponds to the several covariate profiles, and where each row corresponds

--- a/tests/testthat/test-absRisk.R
+++ b/tests/testthat/test-absRisk.R
@@ -178,10 +178,10 @@ test_that("should output probabilities with data frames", {
     absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[1, ],
                               method = "numerical")
 
-    expect_true(all(absRiskMC >= 0))
-    expect_true(all(absRiskNI >= 0))
-    expect_true(all(absRiskMC <= 1))
-    expect_true(all(absRiskNI <= 1))
+    expect_true(all(absRiskMC[, -1] >= 0))
+    expect_true(all(absRiskNI[, -1] >= 0))
+    expect_true(all(absRiskMC[, -1] <= 1))
+    expect_true(all(absRiskNI[, -1] <= 1))
 })
 
 test_that("should output probabilities with data tables", {
@@ -190,10 +190,10 @@ test_that("should output probabilities with data tables", {
     absRiskNI <- absoluteRisk(fitDT, time = 1, newdata = DT[1, ],
                               method = "numerical")
 
-    expect_true(all(absRiskMC >= 0))
-    expect_true(all(absRiskNI >= 0))
-    expect_true(all(absRiskMC <= 1))
-    expect_true(all(absRiskNI <= 1))
+    expect_true(all(absRiskMC[, -1] >= 0))
+    expect_true(all(absRiskNI[, -1] >= 0))
+    expect_true(all(absRiskMC[, -1] <= 1))
+    expect_true(all(absRiskNI[, -1] <= 1))
 })
 
 test_that("should output probabilities with data frames - two time points", {
@@ -227,10 +227,10 @@ test_that(paste("should output probabilities with data frames",
     absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1), ],
                               method = "numerical")
 
-    expect_true(all(absRiskMC >= 0))
-    expect_true(all(absRiskNI >= 0))
-    expect_true(all(absRiskMC <= 1))
-    expect_true(all(absRiskNI <= 1))
+    expect_true(all(absRiskMC[, -1] >= 0))
+    expect_true(all(absRiskNI[, -1] >= 0))
+    expect_true(all(absRiskMC[, -1] <= 1))
+    expect_true(all(absRiskNI[, -1] <= 1))
 })
 
 test_that(paste("should output probabilities with data tables",
@@ -240,15 +240,15 @@ test_that(paste("should output probabilities with data tables",
     absRiskNI <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1), ],
                               method = "numerical")
 
-    expect_true(all(absRiskMC >= 0))
-    expect_true(all(absRiskNI >= 0))
-    expect_true(all(absRiskMC <= 1))
-    expect_true(all(absRiskNI <= 1))
+    expect_true(all(absRiskMC[, -1] >= 0))
+    expect_true(all(absRiskNI[, -1] >= 0))
+    expect_true(all(absRiskMC[, -1] <= 1))
+    expect_true(all(absRiskNI[, -1] <= 1))
 })
 
 # Absolute risk at time = 0
 target <- matrix(0, ncol = 2, nrow = 1)
-class(target) <- c("absRiskCB", class(target))
+# class(target) <- c("absRiskCB", class(target))
 
 test_that("should give probability 0 at time 0 with data frames", {
     absRiskMC <- absoluteRisk(fitDF, time = 0, newdata = newDF,
@@ -256,9 +256,9 @@ test_that("should give probability 0 at time 0 with data frames", {
     absRiskNI <- absoluteRisk(fitDF, time = 0, newdata = newDF,
                               method = "numerical")
 
-    expect_true(all.equal(absRiskMC, target,
+    expect_true(all.equal(absRiskMC[, -1, drop = FALSE], target,
                           check.attributes = FALSE))
-    expect_true(all.equal(absRiskNI, target,
+    expect_true(all.equal(absRiskNI[, -1, drop = FALSE], target,
                           check.attributes = FALSE))
 })
 
@@ -268,9 +268,9 @@ test_that("should give probability 0 at time 0 with data tables", {
     absRiskNI <- absoluteRisk(fitDT, time = 0, newdata = newDT,
                               method = "numerical")
 
-    expect_true(all.equal(absRiskMC, target,
+    expect_true(all.equal(absRiskMC[, -1, drop = FALSE], target,
                           check.attributes = FALSE))
-    expect_true(all.equal(absRiskNI, target,
+    expect_true(all.equal(absRiskNI[, -1, drop = FALSE], target,
                           check.attributes = FALSE))
 })
 

--- a/tests/testthat/test-absRisk.R
+++ b/tests/testthat/test-absRisk.R
@@ -5,34 +5,37 @@ handler_validmc <- function(msg) {
     if (any(grepl("out of range", msg))) invokeRestart("muffleWarning")
 }
 
-n = 100; alpha = 0.05
-
+n <- 100
+alpha <- 0.05
 lambda_t0 <- 1
 lambda_t1 <- 3
 
 times <- c(rexp(n = n, rate = lambda_t0),
            rexp(n = n, rate = lambda_t1))
-censor <- rexp(n = 2*n, rate = -log(alpha))
+censor <- rexp(n = 2 * n, rate = -log(alpha))
 
 times_c <- pmin(times, censor)
 event_c <- 1 * (times < censor)
 
 DF <- data.frame("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 DT <- data.table("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 
 fitDF <- fitSmoothHazard(event ~ Z, data = DF, time = "ftime", ratio = 10)
 fitDT <- fitSmoothHazard(event ~ Z, data = DT, time = "ftime", ratio = 10)
 
 test_that("no error in absolute risk with data frames", {
-    foo1 <- try(withCallingHandlers(absoluteRisk(fitDF, time = 1, newdata = DF[1,],
+    foo1 <- try(withCallingHandlers(absoluteRisk(fitDF, time = 1,
+                                                 newdata = DF[1, ],
                                                  method = "montecarlo"),
                                     warning = handler_validmc),
                 silent = TRUE)
-    foo2 <- try(absoluteRisk(fitDF, time = 1, newdata = DF[1,],
+    foo2 <- try(absoluteRisk(fitDF, time = 1, newdata = DF[1, ],
                              method = "numerical"),
                 silent = TRUE)
 
@@ -41,11 +44,12 @@ test_that("no error in absolute risk with data frames", {
 })
 
 test_that("no error in absolute risk with data tables", {
-    foo1 <- try(withCallingHandlers(absoluteRisk(fitDT, time = 1, newdata = DT[1,],
+    foo1 <- try(withCallingHandlers(absoluteRisk(fitDT, time = 1,
+                                                 newdata = DT[1, ],
                                                  method = "montecarlo"),
                                     warning = handler_validmc),
                 silent = TRUE)
-    foo2 <- try(absoluteRisk(fitDT, time = 1, newdata = DT[1,],
+    foo2 <- try(absoluteRisk(fitDT, time = 1, newdata = DT[1, ],
                              method = "numerical"),
                 silent = TRUE)
 
@@ -110,11 +114,12 @@ test_that("no error in absolute risk with data tables--typical profile", {
 })
 
 # Using new data
-newDT <- data.table("Z" = c(0,1))
+newDT <- data.table("Z" = c(0, 1))
 newDF <- data.frame("Z" = c(0,1))
 
 test_that("no error in absolute risk with data frames - new data", {
-    foo1 <- try(withCallingHandlers(absoluteRisk(fitDF, time = 1, newdata = newDF,
+    foo1 <- try(withCallingHandlers(absoluteRisk(fitDF, time = 1,
+                                                 newdata = newDF,
                              method = "montecarlo"),
                              warning = handler_validmc),
                 silent = TRUE)
@@ -127,7 +132,8 @@ test_that("no error in absolute risk with data frames - new data", {
 })
 
 test_that("no error in absolute risk with data tables - new data", {
-    foo1 <- try(withCallingHandlers(absoluteRisk(fitDT, time = 1, newdata = newDT,
+    foo1 <- try(withCallingHandlers(absoluteRisk(fitDT, time = 1,
+                                                 newdata = newDT,
                              method = "montecarlo"),
                              warning = handler_validmc),
                 silent = TRUE)
@@ -167,9 +173,9 @@ test_that("no error in absolute risk with data tables - new data but no time", {
 
 # Make sure we get probabilities
 test_that("should output probabilities with data frames", {
-    absRiskMC <- absoluteRisk(fitDF, time = 1, newdata = DF[1,],
+    absRiskMC <- absoluteRisk(fitDF, time = 1, newdata = DF[1, ],
                               method = "montecarlo")
-    absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[1,],
+    absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[1, ],
                               method = "numerical")
 
     expect_true(all(absRiskMC >= 0))
@@ -179,9 +185,9 @@ test_that("should output probabilities with data frames", {
 })
 
 test_that("should output probabilities with data tables", {
-    absRiskMC <- absoluteRisk(fitDT, time = 1, newdata = DT[1,],
+    absRiskMC <- absoluteRisk(fitDT, time = 1, newdata = DT[1, ],
                               method = "montecarlo")
-    absRiskNI <- absoluteRisk(fitDT, time = 1, newdata = DT[1,],
+    absRiskNI <- absoluteRisk(fitDT, time = 1, newdata = DT[1, ],
                               method = "numerical")
 
     expect_true(all(absRiskMC >= 0))
@@ -191,33 +197,34 @@ test_that("should output probabilities with data tables", {
 })
 
 test_that("should output probabilities with data frames - two time points", {
-    absRiskMC <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1,],
+    absRiskMC <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1, ],
                               method = "montecarlo")
-    absRiskNI <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1,],
+    absRiskNI <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1, ],
                               method = "numerical")
 
-    expect_true(all(absRiskMC[,-1] >= 0))
-    expect_true(all(absRiskNI[,-1] >= 0))
-    expect_true(all(absRiskMC[,-1] <= 1))
-    expect_true(all(absRiskNI[,-1] <= 1))
+    expect_true(all(absRiskMC[, -1] >= 0))
+    expect_true(all(absRiskNI[, -1] >= 0))
+    expect_true(all(absRiskMC[, -1] <= 1))
+    expect_true(all(absRiskNI[, -1] <= 1))
 })
 
 test_that("should output probabilities with data tables - two time points", {
-    absRiskMC <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1,],
+    absRiskMC <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1, ],
                               method = "montecarlo")
-    absRiskNI <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1,],
+    absRiskNI <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1, ],
                               method = "numerical")
 
-    expect_true(all(absRiskMC[,-1] >= 0))
-    expect_true(all(absRiskNI[,-1] >= 0))
-    expect_true(all(absRiskMC[,-1] <= 1))
-    expect_true(all(absRiskNI[,-1] <= 1))
+    expect_true(all(absRiskMC[, -1] >= 0))
+    expect_true(all(absRiskNI[, -1] >= 0))
+    expect_true(all(absRiskMC[, -1] <= 1))
+    expect_true(all(absRiskNI[, -1] <= 1))
 })
 
-test_that("should output probabilities with data frames - two covariate profile", {
-    absRiskMC <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1),],
+test_that(paste("should output probabilities with data frames",
+                "- two covariate profile"), {
+    absRiskMC <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1), ],
                               method = "montecarlo")
-    absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1),],
+    absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1), ],
                               method = "numerical")
 
     expect_true(all(absRiskMC >= 0))
@@ -226,10 +233,11 @@ test_that("should output probabilities with data frames - two covariate profile"
     expect_true(all(absRiskNI <= 1))
 })
 
-test_that("should output probabilities with data tables - two covariate profile", {
-    absRiskMC <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1),],
+test_that(paste("should output probabilities with data tables",
+                "- two covariate profile"), {
+    absRiskMC <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1), ],
                               method = "montecarlo")
-    absRiskNI <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1),],
+    absRiskNI <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1), ],
                               method = "numerical")
 
     expect_true(all(absRiskMC >= 0))
@@ -276,27 +284,27 @@ test_that("should compute risk when time and newdata aren't provided", {
 
 # Control output----
 test_that("should output probabilities with data frames - two time points", {
-    absRiskMC <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1,],
+    absRiskMC <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1, ],
                               method = "montecarlo", type = "survival")
-    absRiskNI <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1,],
+    absRiskNI <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1, ],
                               method = "numerical", type = "survival")
 
-    expect_true(all(absRiskMC[,-1] >= 0))
-    expect_true(all(absRiskNI[,-1] >= 0))
-    expect_true(all(absRiskMC[,-1] <= 1))
-    expect_true(all(absRiskNI[,-1] <= 1))
+    expect_true(all(absRiskMC[, -1] >= 0))
+    expect_true(all(absRiskNI[, -1] >= 0))
+    expect_true(all(absRiskMC[, -1] <= 1))
+    expect_true(all(absRiskNI[, -1] <= 1))
 })
 
 test_that("should output probabilities with data tables - two time points", {
-    absRiskMC <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1,],
+    absRiskMC <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1, ],
                               method = "montecarlo", type = "survival")
-    absRiskNI <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1,],
+    absRiskNI <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1, ],
                               method = "numerical", type = "survival")
 
-    expect_true(all(absRiskMC[,-1] >= 0))
-    expect_true(all(absRiskNI[,-1] >= 0))
-    expect_true(all(absRiskMC[,-1] <= 1))
-    expect_true(all(absRiskNI[,-1] <= 1))
+    expect_true(all(absRiskMC[, -1] >= 0))
+    expect_true(all(absRiskNI[, -1] >= 0))
+    expect_true(all(absRiskMC[, -1] <= 1))
+    expect_true(all(absRiskNI[, -1] <= 1))
 })
 
 test_that("should compute survival when time and newdata aren't provided", {
@@ -308,9 +316,9 @@ test_that("should compute survival when time and newdata aren't provided", {
 })
 
 test_that("shouldn't output time zero with data frames - two time points", {
-    absRiskMC <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1,],
+    absRiskMC <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1, ],
                               method = "montecarlo", addZero = FALSE)
-    absRiskNI <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1,],
+    absRiskNI <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1, ],
                               method = "numerical", addZero = FALSE)
 
     expect_true(nrow(absRiskMC) == 2)
@@ -318,9 +326,9 @@ test_that("shouldn't output time zero with data frames - two time points", {
 })
 
 test_that("shouldn't output time zero with data tables - two time points", {
-    absRiskMC <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1,],
+    absRiskMC <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1, ],
                               method = "montecarlo", addZero = FALSE)
-    absRiskNI <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1,],
+    absRiskNI <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1, ],
                               method = "numerical", addZero = FALSE)
 
     expect_true(nrow(absRiskMC) == 2)

--- a/tests/testthat/test-absRiskComp.R
+++ b/tests/testthat/test-absRiskComp.R
@@ -5,8 +5,8 @@ handler_validmc <- function(msg) {
     if (any(grepl("out of range", msg))) invokeRestart("muffleWarning")
 }
 
-n = 100; alpha = 0.05
-
+n <- 100
+alpha <- 0.05
 lambda10 <- 1
 lambda20 <- 2
 lambda11 <- 4
@@ -26,7 +26,8 @@ event_c <- event * (times < censor)
 
 DT <- data.table("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 
 DF <- data.frame("ftime" = times_c,
                  "event" = event_c,
@@ -36,7 +37,8 @@ fitDF <- fitSmoothHazard(event ~ Z, data = DF, time = "ftime")
 fitDT <- fitSmoothHazard(event ~ Z, data = DT, time = "ftime")
 
 test_that("no error in absolute risk with data frames", {
-    foo1 <- try(withCallingHandlers(absoluteRisk(fitDF, time = 1, newdata = DF[1,],
+    foo1 <- try(withCallingHandlers(absoluteRisk(fitDF, time = 1,
+                                                 newdata = DF[1, ],
                              method = "montecarlo", nsamp = 10),
                              warning = handler_validmc),
                 silent = TRUE)
@@ -49,7 +51,8 @@ test_that("no error in absolute risk with data frames", {
 })
 
 test_that("no error in absolute risk with data tables", {
-    foo1 <- try(withCallingHandlers(absoluteRisk(fitDT, time = 1, newdata = DT[1,],
+    foo1 <- try(withCallingHandlers(absoluteRisk(fitDT, time = 1,
+                                                 newdata = DT[1, ],
                              method = "montecarlo", nsamp = 10),
                              warning = handler_validmc),
                 silent = TRUE)
@@ -66,7 +69,8 @@ newDT <- data.table("Z" = c(0,1))
 newDF <- data.frame("Z" = c(0,1))
 
 test_that("no error in absolute risk with data frames - new data", {
-    foo1 <- try(withCallingHandlers(absoluteRisk(fitDF, time = 1, newdata = newDF,
+    foo1 <- try(withCallingHandlers(absoluteRisk(fitDF, time = 1,
+                                                 newdata = newDF,
                              method = "montecarlo", nsamp = 10),
                              warning = handler_validmc),
                 silent = TRUE)
@@ -79,7 +83,8 @@ test_that("no error in absolute risk with data frames - new data", {
 })
 
 test_that("no error in absolute risk with data tables - new data", {
-    foo1 <- try(withCallingHandlers(absoluteRisk(fitDT, time = 1, newdata = newDT,
+    foo1 <- try(withCallingHandlers(absoluteRisk(fitDT, time = 1,
+                                                 newdata = newDT,
                              method = "montecarlo", nsamp = 10),
                              warning = handler_validmc),
                 silent = TRUE)
@@ -140,10 +145,11 @@ test_that("should output probabilities with data tables - two time points", {
     expect_true(all(absRiskNI[,-1] <= 1))
 })
 
-test_that("should output probabilities with data frames - two covariate profile", {
+test_that(paste("should output probabilities with data frames",
+                "- two covariate profile"), {
     # absRiskMC <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1),],
     #                           method = "montecarlo", nsamp = 10)
-    absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1),],
+    absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1), ],
                               method = "numerical")
 
     # expect_true(all(absRiskMC >= 0))
@@ -152,7 +158,8 @@ test_that("should output probabilities with data frames - two covariate profile"
     expect_true(all(absRiskNI <= 1))
 })
 
-test_that("should output probabilities with data tables - two covariate profile", {
+test_that(paste("should output probabilities with data tables",
+                "- two covariate profile"), {
     # absRiskMC <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1),],
     #                           method = "montecarlo", nsamp = 10)
     absRiskNI <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1),],
@@ -163,100 +170,3 @@ test_that("should output probabilities with data tables - two covariate profile"
     # expect_true(all(absRiskMC <= 1))
     expect_true(all(absRiskNI <= 1))
 })
-
-# Competing Risks and glmnet----
-# extra_vars <- matrix(rnorm(10 * n), ncol = 10)
-# DF_ext <- cbind(DF, as.data.frame(extra_vars))
-# DT_ext <- cbind(DT, as.data.table(extra_vars))
-# formula_glmnet <- formula(paste(c("event ~ ftime", "Z",
-#                                   paste0("V", 1:10)),
-#                                 collapse = " + "))
-#
-# test_that("no error in fitting glmnet", {
-#     fitDF_glmnet <- try(fitSmoothHazard(formula_glmnet, data = DF_ext, time = "ftime",
-#                                         family = "glmnet", ratio = 10,
-#                                         lambda = c(0, 0.5)),
-#                         silent = TRUE)
-#     fitDT_glmnet <- try(fitSmoothHazard(formula_glmnet, data = DT_ext, time = "ftime",
-#                                         family = "glmnet", ratio = 10,
-#                                         lambda = c(0, 0.5)),
-#                         silent = TRUE)
-#     expect_false(inherits(fitDF_glmnet, "try-error"))
-#     expect_false(inherits(fitDT_glmnet, "try-error"))
-# })
-#
-# y <- cbind(time = DF_ext$ftime,
-#            status = DF_ext$event)
-# x <- subset(DF_ext, select = !(colnames(DF_ext) %in% c("ftime", "event")))
-# x <- as.matrix(x)
-#
-# test_that("no error in fitting fitSmoothHazard.fit", {
-#     fit_glmnet <- try(fitSmoothHazard.fit(x, y, time = "time", event = "status",
-#                                           family = "glmnet", ratio = 10,
-#                                           lambda = c(0, 0.5)),
-#                       silent = TRUE)
-#
-#     expect_false(inherits(fit_glmnet, "try-error"))
-# })
-#
-# new_x <- x[1:5, ]
-#
-# test_that("no error in absolute risk - new data", {
-#     fit_glmnet <- try(fitSmoothHazard.fit(x, y, time = "time", event = "status",
-#                                           family = "glmnet", ratio = 10,
-#                                           lambda = c(0, 0.5)),
-#                       silent = TRUE)
-#     expect_warning(foo1 <- try(absoluteRisk(fit_glmnet, time = 1,
-#                                             newdata = new_x,
-#                                             method = "montecarlo",
-#                                             nsamp = 10),
-#                                silent = TRUE))
-#     expect_warning(foo2 <- try(absoluteRisk(fit_glmnet, time = 1,
-#                                             newdata = new_x,
-#                                             method = "numerical"),
-#                                silent = TRUE))
-#
-#     expect_false(inherits(foo1, "try-error"))
-#     expect_false(inherits(foo2, "try-error"))
-# })
-#
-# newDF_ext <- DF_ext[1:5,]
-# newDT_ext <- DT_ext[1:5,]
-#
-# test_that("no error in absolute risk with data frames - new data", {
-#     fitDF_glmnet <- try(fitSmoothHazard(formula_glmnet, data = DF_ext, time = "ftime",
-#                                         family = "glmnet", ratio = 10,
-#                                         lambda = c(0, 0.5)),
-#                         silent = TRUE)
-#     expect_warning(foo1 <- try(absoluteRisk(fitDF_glmnet, time = 1,
-#                                             newdata = newDF_ext,
-#                                             method = "montecarlo",
-#                                             nsamp = 10),
-#                                silent = TRUE))
-#     expect_warning(foo2 <- try(absoluteRisk(fitDF_glmnet, time = 1,
-#                                             newdata = newDF_ext,
-#                                             method = "numerical"),
-#                                silent = TRUE))
-#
-#     expect_false(inherits(foo1, "try-error"))
-#     expect_false(inherits(foo2, "try-error"))
-# })
-#
-# test_that("no error in absolute risk with data tables - new data", {
-#     fitDT_glmnet <- try(fitSmoothHazard(formula_glmnet, data = DT_ext, time = "ftime",
-#                                         family = "glmnet", ratio = 10,
-#                                         lambda = c(0, 0.5)),
-#                         silent = TRUE)
-#     expect_warning(foo1 <- try(absoluteRisk(fitDT_glmnet, time = 1,
-#                                             newdata = newDT_ext,
-#                                             method = "montecarlo",
-#                                             nsamp = 10),
-#                                silent = TRUE))
-#     expect_warning(foo2 <- try(absoluteRisk(fitDT_glmnet, time = 1,
-#                                          newdata = newDT_ext,
-#                                          method = "numerical"),
-#                                silent = TRUE))
-#
-#     expect_false(inherits(foo1, "try-error"))
-#     expect_false(inherits(foo2, "try-error"))
-# })

--- a/tests/testthat/test-absRiskComp.R
+++ b/tests/testthat/test-absRiskComp.R
@@ -98,75 +98,101 @@ test_that("no error in absolute risk with data tables - new data", {
 
 # Make sure we get probabilities
 test_that("should output probabilities with data frames", {
-    # absRiskMC <- absoluteRisk(fitDF, time = 1, newdata = DF[1,],
-    #                           method = "montecarlo", nsamp = 10)
+    absRiskMC <- absoluteRisk(fitDF, time = 1, newdata = DF[1,],
+                              method = "montecarlo")
     absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[1,],
                               method = "numerical")
 
-    # expect_true(all(absRiskMC >= 0))
-    expect_true(all(absRiskNI >= 0))
-    # expect_true(all(absRiskMC <= 1))
-    expect_true(all(absRiskNI <= 1))
+    expect_true(all(absRiskMC[,-1] >= 0))
+    expect_true(all(absRiskNI[,-1] >= 0))
+    expect_true(all(absRiskMC[,-1] <= 1))
+    expect_true(all(absRiskNI[,-1] <= 1))
 })
 
 test_that("should output probabilities with data tables", {
-    # absRiskMC <- absoluteRisk(fitDT, time = 1, newdata = DT[1,],
-    #                           method = "montecarlo", nsamp = 10)
+    absRiskMC <- absoluteRisk(fitDT, time = 1, newdata = DT[1,],
+                              method = "montecarlo")
     absRiskNI <- absoluteRisk(fitDT, time = 1, newdata = DT[1,],
                               method = "numerical")
 
-    # expect_true(all(absRiskMC >= 0))
-    expect_true(all(absRiskNI >= 0))
-    # expect_true(all(absRiskMC <= 1))
-    expect_true(all(absRiskNI <= 1))
+    expect_true(all(absRiskMC[,-1] >= 0))
+    expect_true(all(absRiskNI[,-1] >= 0))
+    expect_true(all(absRiskMC[,-1] <= 1))
+    expect_true(all(absRiskNI[,-1] <= 1))
 })
 
 test_that("should output probabilities with data frames - two time points", {
-    # absRiskMC <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1,],
-    #                           method = "montecarlo", nsamp = 10)
+    absRiskMC <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1,],
+                              method = "montecarlo")
     absRiskNI <- absoluteRisk(fitDF, time = c(0.5, 1), newdata = DF[1,],
                               method = "numerical")
 
-    # expect_true(all(absRiskMC[,-1] >= 0))
+    expect_true(all(absRiskMC[,-1] >= 0))
     expect_true(all(absRiskNI[,-1] >= 0))
-    # expect_true(all(absRiskMC[,-1] <= 1))
+    expect_true(all(absRiskMC[,-1] <= 1))
     expect_true(all(absRiskNI[,-1] <= 1))
 })
 
 test_that("should output probabilities with data tables - two time points", {
-    # absRiskMC <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1,],
-    #                           method = "montecarlo", nsamp = 10)
+    absRiskMC <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1,],
+                              method = "montecarlo")
     absRiskNI <- absoluteRisk(fitDT, time = c(0.5, 1), newdata = DT[1,],
                               method = "numerical")
 
-    # expect_true(all(absRiskMC[,-1] >= 0))
+    expect_true(all(absRiskMC[,-1] >= 0))
     expect_true(all(absRiskNI[,-1] >= 0))
-    # expect_true(all(absRiskMC[,-1] <= 1))
+    expect_true(all(absRiskMC[,-1] <= 1))
     expect_true(all(absRiskNI[,-1] <= 1))
 })
 
 test_that(paste("should output probabilities with data frames",
                 "- two covariate profile"), {
-    # absRiskMC <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1),],
-    #                           method = "montecarlo", nsamp = 10)
+    absRiskMC <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1),],
+                              method = "montecarlo")
     absRiskNI <- absoluteRisk(fitDF, time = 1, newdata = DF[c(1, n + 1), ],
                               method = "numerical")
 
-    # expect_true(all(absRiskMC >= 0))
+    expect_true(all(absRiskMC >= 0))
     expect_true(all(absRiskNI >= 0))
-    # expect_true(all(absRiskMC <= 1))
+    expect_true(all(absRiskMC <= 1))
     expect_true(all(absRiskNI <= 1))
 })
 
 test_that(paste("should output probabilities with data tables",
                 "- two covariate profile"), {
-    # absRiskMC <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1),],
-    #                           method = "montecarlo", nsamp = 10)
+    absRiskMC <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1),],
+                              method = "montecarlo")
     absRiskNI <- absoluteRisk(fitDT, time = 1, newdata = DT[c(1, n + 1),],
                               method = "numerical")
 
-    # expect_true(all(absRiskMC >= 0))
+    expect_true(all(absRiskMC >= 0))
     expect_true(all(absRiskNI >= 0))
-    # expect_true(all(absRiskMC <= 1))
+    expect_true(all(absRiskMC <= 1))
     expect_true(all(absRiskNI <= 1))
+})
+
+test_that("no error in absolute risk with type survival", {
+    foo1 <- try(withCallingHandlers(absoluteRisk(fitDF, time = 1,
+                                                 newdata = newDF,
+                                                 method = "montecarlo",
+                                                 type = "survival"),
+                                    warning = handler_validmc),
+                silent = TRUE)
+    foo2 <- try(absoluteRisk(fitDF, time = 1, newdata = newDF,
+                             method = "numerical", type = "survival"),
+                silent = TRUE)
+    foo3 <- try(withCallingHandlers(absoluteRisk(fitDT, time = 1,
+                                                 newdata = newDT,
+                                                 method = "montecarlo",
+                                                 type = "survival"),
+                                    warning = handler_validmc),
+                silent = TRUE)
+    foo4 <- try(absoluteRisk(fitDT, time = 1, newdata = newDT,
+                             method = "numerical", type = "survival"),
+                silent = TRUE)
+
+    expect_false(inherits(foo1, "try-error"))
+    expect_false(inherits(foo2, "try-error"))
+    expect_false(inherits(foo3, "try-error"))
+    expect_false(inherits(foo4, "try-error"))
 })

--- a/tests/testthat/test-fitting.R
+++ b/tests/testthat/test-fitting.R
@@ -1,7 +1,7 @@
 context("Fitting")
 
-n = 100; alpha = 0.05
-
+n <- 100
+alpha <- 0.05
 lambda_t0 <- 1
 lambda_t1 <- 3
 
@@ -14,10 +14,12 @@ event_c <- 1 * (times < censor)
 
 DF <- data.frame("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 DT <- data.table("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 
 test_that("no error in fitting with data.frame and data.table", {
     fitDF <- try(fitSmoothHazard(event ~ Z, data = DF, time = "ftime"),
@@ -30,14 +32,16 @@ test_that("no error in fitting with data.frame and data.table", {
 })
 
 test_that("allow dot notation in formula", {
-    try(model <- fitSmoothHazard(DeadOfPrCa ~ ., data = ERSPC, time='Follow.Up.Time', ratio = 100),
+    try(model <- fitSmoothHazard(DeadOfPrCa ~ ., data = ERSPC,
+                                 time = "Follow.Up.Time", ratio = 100),
         silent = TRUE)
 
     expect_false(inherits(model, "try-error"))
 })
 
 test_that("sampling first and then fitting", {
-    data_cb <- sampleCaseBase(ERSPC, time='Follow.Up.Time', ratio = 10, event = "DeadOfPrCa")
+    data_cb <- sampleCaseBase(ERSPC, time = "Follow.Up.Time",
+                              ratio = 10, event = "DeadOfPrCa")
     try(model <- fitSmoothHazard(DeadOfPrCa ~ ., data = data_cb),
         silent = TRUE)
 
@@ -50,7 +54,7 @@ form <- formula(event ~ exposure + time)
 form_bs <- formula(event ~ exposure + bs(time))
 form_log <- formula(event ~ exposure + log(time))
 form_int <- formula(event ~ exposure*time)
-form_nested <- formula(cens ~ horTh*nsx(log(time), df = 3) + age*time)
+form_nested <- formula(cens ~ horTh * nsx(log(time), df = 3) + age * time)
 
 form_bs_extra <- formula(event ~ exposure + bs(time, df = 3))
 form_bs_named <- formula(event ~ exposure + bs(x = time))
@@ -74,7 +78,7 @@ wrong_int <- formula(event ~ exposure*wrongtime + time)
 wrong2 <- formula(event ~ exposure + time + timewrong)
 wrong2_bs <- formula(event ~ exposure + time + bs(timewrong))
 wrong2_log <- formula(event ~ exposure + time + log(timewrong))
-wrong2_int <- formula(event ~ exposure*timewrong + time)
+wrong2_int <- formula(event ~ exposure * timewrong + time)
 
 test_that("Making sure we don't pick up anything that looks like time", {
     expect_false(detect_nonlinear_time(wrong, "time"))

--- a/tests/testthat/test-fittingComp.R
+++ b/tests/testthat/test-fittingComp.R
@@ -1,7 +1,7 @@
 context("Fitting-Comp risk")
 
-n = 100; alpha = 0.05
-
+n <- 100
+alpha <- 0.05
 lambda10 <- 1
 lambda20 <- 2
 lambda11 <- 4
@@ -14,18 +14,20 @@ times <- c(rexp(n = n, rate = lambda_t0),
            rexp(n = n, rate = lambda_t1))
 event <- c(rbinom(n, 1, prob = lambda10/lambda_t0),
            rbinom(n, 1, prob = lambda11/lambda_t1)) + 1
-censor <- rexp(n = 2*n, rate = -log(alpha))
+censor <- rexp(n = 2 * n, rate = -log(alpha))
 
 times_c <- pmin(times, censor)
 event_c <- event * (times < censor)
 
 DT <- data.table("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 
 DF <- data.frame("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 
 test_that("no error in fitting with data.frame and data.table", {
     fitDF <- try(fitSmoothHazard(event ~ Z, data = DF, time = "ftime"),

--- a/tests/testthat/test-gam.R
+++ b/tests/testthat/test-gam.R
@@ -4,24 +4,26 @@ context("GAMs")
 testthat::skip_if_not_installed("mgcv")
 
 # Create data----
-n = 100; alpha = 0.05
-
+n <- 100
+alpha <- 0.05
 lambda_t0 <- 1
 lambda_t1 <- 3
 
 times <- c(rexp(n = n, rate = lambda_t0),
            rexp(n = n, rate = lambda_t1))
-censor <- rexp(n = 2*n, rate = -log(alpha))
+censor <- rexp(n = 2 * n, rate = -log(alpha))
 
 times_c <- pmin(times, censor)
 event_c <- 1 * (times < censor)
 
 DF <- data.frame("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 DT <- data.table("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 
 extra_vars <- matrix(rnorm(10 * n), ncol = 10)
 DF_ext <- cbind(DF, as.data.frame(extra_vars))
@@ -33,9 +35,11 @@ formula_gam <- formula(paste(c("event ~ s(ftime)", "Z",
 
 # Fitting----
 test_that("no error in fitting gam", {
-    fitDF <- try(fitSmoothHazard(formula_gam, data = DF_ext, time = "ftime", family = "gam"),
+    fitDF <- try(fitSmoothHazard(formula_gam, data = DF_ext, time = "ftime",
+                                 family = "gam"),
                  silent = TRUE)
-    fitDT <- try(fitSmoothHazard(formula_gam, data = DT_ext, time = "ftime", family = "gam"),
+    fitDT <- try(fitSmoothHazard(formula_gam, data = DT_ext, time = "ftime",
+                                 family = "gam"),
                  silent = TRUE)
 
     expect_false(inherits(fitDF, "try-error"))
@@ -48,8 +52,8 @@ fitDF_gam <- fitSmoothHazard(event ~ s(ftime) + Z, data = DF,
 fitDT_gam <- fitSmoothHazard(event ~ s(ftime) + Z, data = DT,
                              time = "ftime", family = "gam", ratio = 10)
 
-newDT <- data.table("Z" = c(0,1))
-newDF <- data.frame("Z" = c(0,1))
+newDT <- data.table("Z" = c(0, 1))
+newDF <- data.frame("Z" = c(0, 1))
 
 test_that("no error in abs risk for gam", {
     riskDF <- try(absoluteRisk(fitDF_gam, time = 0.5, newdata = newDF),
@@ -78,8 +82,10 @@ test_that("should compute risk when time and newdata aren't provided", {
 })
 
 test_that("output probabilities", {
-    riskDF_gam <- absoluteRisk(fitDF_gam, time = 0.5, newdata = newDF, family = "gam")
-    riskDT_gam <- absoluteRisk(fitDT_gam, time = 0.5, newdata = newDT, family = "gam")
+    riskDF_gam <- absoluteRisk(fitDF_gam, time = 0.5, newdata = newDF,
+                               family = "gam")
+    riskDT_gam <- absoluteRisk(fitDT_gam, time = 0.5, newdata = newDT,
+                               family = "gam")
 
     expect_true(all(riskDF_gam >= 0))
     expect_true(all(riskDT_gam >= 0))

--- a/tests/testthat/test-glmnet.R
+++ b/tests/testthat/test-glmnet.R
@@ -4,24 +4,26 @@ context("glmnet")
 testthat::skip_if_not_installed("glmnet")
 
 # Create data----
-n = 100; alpha = 0.05
-
+n <- 100
+alpha <- 0.05
 lambda_t0 <- 1
 lambda_t1 <- 3
 
 times <- c(rexp(n = n, rate = lambda_t0),
            rexp(n = n, rate = lambda_t1))
-censor <- rexp(n = 2*n, rate = -log(alpha))
+censor <- rexp(n = 2 * n, rate = -log(alpha))
 
 times_c <- pmin(times, censor)
 event_c <- 1 * (times < censor)
 
 DF <- data.frame("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 DT <- data.table("ftime" = times_c,
                  "event" = event_c,
-                 "Z" = c(rep(0,n), rep(1,n)))
+                 "Z" = c(rep(0, n),
+                         rep(1, n)))
 
 extra_vars <- matrix(rnorm(10 * n), ncol = 10)
 DF_ext <- cbind(DF, as.data.frame(extra_vars))
@@ -33,9 +35,11 @@ formula_glmnet <- formula(paste(c("event ~ ftime", "Z",
 
 # Fitting----
 test_that("no error in fitting glmnet", {
-    fitDF <- try(fitSmoothHazard(formula_glmnet, data = DF_ext, time = "ftime", family = "glmnet"),
+    fitDF <- try(fitSmoothHazard(formula_glmnet, data = DF_ext, time = "ftime",
+                                 family = "glmnet"),
                  silent = TRUE)
-    fitDT <- try(fitSmoothHazard(formula_glmnet, data = DT_ext, time = "ftime", family = "glmnet"),
+    fitDT <- try(fitSmoothHazard(formula_glmnet, data = DT_ext, time = "ftime",
+                                 family = "glmnet"),
                  silent = TRUE)
 
     expect_false(inherits(fitDF, "try-error"))
@@ -43,8 +47,10 @@ test_that("no error in fitting glmnet", {
 })
 
 # Absolute risk----
-fitDF_glmnet <- fitSmoothHazard(formula_glmnet, data = DF_ext, time = "ftime", family = "glmnet", ratio = 10)
-fitDT_glmnet <- fitSmoothHazard(formula_glmnet, data = DT_ext, time = "ftime", family = "glmnet", ratio = 10)
+fitDF_glmnet <- fitSmoothHazard(formula_glmnet, data = DF_ext, time = "ftime",
+                                family = "glmnet", ratio = 10)
+fitDT_glmnet <- fitSmoothHazard(formula_glmnet, data = DT_ext, time = "ftime",
+                                family = "glmnet", ratio = 10)
 
 newDT <- data.table("Z" = c(0,1))
 newDF <- data.frame("Z" = c(0,1))
@@ -76,9 +82,11 @@ test_that("no error in fitting glmnet", {
 })
 
 test_that("no error in using custom lambda in glmnet", {
-    riskDF <- try(absoluteRisk(fitDF_glmnet, time = 0.5, newdata = newDF_ext, s = 0.1),
+    riskDF <- try(absoluteRisk(fitDF_glmnet, time = 0.5, newdata = newDF_ext,
+                               s = 0.1),
                   silent = TRUE)
-    riskDT <- try(absoluteRisk(fitDT_glmnet, time = 0.5, newdata = newDT_ext, s = 0.1),
+    riskDT <- try(absoluteRisk(fitDT_glmnet, time = 0.5, newdata = newDT_ext,
+                               s = 0.1),
                   silent = TRUE)
 
     expect_false(inherits(riskDF, "try-error"))
@@ -86,8 +94,10 @@ test_that("no error in using custom lambda in glmnet", {
 })
 
 test_that("output probabilities", {
-    riskDF_glmnet <- absoluteRisk(fitDF_glmnet, time = 0.5, newdata = newDF_ext, family = "glmnet")
-    riskDT_glmnet <- absoluteRisk(fitDT_glmnet, time = 0.5, newdata = newDT_ext, family = "glmnet")
+    riskDF_glmnet <- absoluteRisk(fitDF_glmnet, time = 0.5, newdata = newDF_ext,
+                                  family = "glmnet")
+    riskDT_glmnet <- absoluteRisk(fitDT_glmnet, time = 0.5, newdata = newDT_ext,
+                                  family = "glmnet")
 
     expect_true(all(riskDF_glmnet >= 0))
     expect_true(all(riskDT_glmnet >= 0))
@@ -107,7 +117,7 @@ ty <- rexp(N,hx)
 tcens <- rbinom(n = N,
                 prob = 0.3,
                 size = 1) # censoring indicator
-y <- cbind(time = ty, status = 1 - tcens) # y=Surv(ty,1-tcens) with library(survival)
+y <- cbind(time = ty, status = 1 - tcens) # y=Surv(ty,1-tcens) with survival
 
 test_that("no error in fitting fitSmoothHazard.fit", {
     fit_glmnet <- try(fitSmoothHazard.fit(x, y, time = "time", event = "status",
@@ -127,14 +137,14 @@ test_that("no error in using nonlinear functions of time", {
                                           lambda = c(0, 0.5)),
                       silent = TRUE)
 
-    fit_glmnet_splines <- try(fitSmoothHazard.fit(x, y, formula_time = ~ bs(time),
-                                                  time = "time", event = "status",
-                                                  family = "glmnet", ratio = 10,
-                                                  lambda = c(0, 0.5)),
+    fit_glmnet_sp <- try(fitSmoothHazard.fit(x, y, formula_time = ~ bs(time),
+                                             time = "time", event = "status",
+                                             family = "glmnet", ratio = 10,
+                                             lambda = c(0, 0.5)),
                               silent = TRUE)
 
     expect_false(inherits(fit_glmnet, "try-error"))
-    expect_false(inherits(fit_glmnet_splines, "try-error"))
+    expect_false(inherits(fit_glmnet_sp, "try-error"))
 })
 
 # Absolute risk with matrix interface----
@@ -169,12 +179,14 @@ test_that("we get probabilities", {
 
 test_that("should compute risk when time and newdata aren't provided", {
     fit_glmnet_red <- fit_glmnet
-    fit_glmnet_red$originalData$x <- fit_glmnet_red$originalData$x[c(1:2, 101:102),]
+    fit_glmnet_red$originalData$x <- fit_glmnet_red$originalData$x[c(1:2,
+                                                                     101:102), ]
     risk <- try(absoluteRisk(fit_glmnet_red, nsamp = 10),
                 silent = TRUE)
-    fit_glmnet_log_red <- fit_glmnet_log
-    fit_glmnet_log_red$originalData$x <- fit_glmnet_log_red$originalData$x[c(1:2, 101:102),]
-    risk_log <- try(absoluteRisk(fit_glmnet_log_red, nsamp = 100),
+    fit_glmnetred2 <- fit_glmnet_log
+    fit_glmnetred2$originalData$x <- fit_glmnetred2$originalData$x[c(1:2,
+                                                                     101:102), ]
+    risk_log <- try(absoluteRisk(fit_glmnetred2, nsamp = 100),
                     silent = TRUE)
 
     expect_false(inherits(risk, "try-error"))
@@ -182,10 +194,10 @@ test_that("should compute risk when time and newdata aren't provided", {
 })
 
 # Test absoluteRisk--two time points
-risk <- try(absoluteRisk(fit_glmnet, time = c(1,2),
+risk <- try(absoluteRisk(fit_glmnet, time = c(1, 2),
                          newdata = new_x, nsamp = 100),
             silent = TRUE)
-risk_log <- try(absoluteRisk(fit_glmnet_log, time = c(1,2),
+risk_log <- try(absoluteRisk(fit_glmnet_log, time = c(1, 2),
                              newdata = new_x, nsamp = 100),
                 silent = TRUE)
 
@@ -196,8 +208,8 @@ test_that("no error in absoluteRisk with glmnet", {
 })
 
 test_that("we get probabilities", {
-    expect_true(all(risk[,-1] >= 0))
-    expect_true(all(risk[,-1] <= 1))
-    expect_true(all(risk_log[,-1] >= 0))
-    expect_true(all(risk_log[,-1] <= 1))
+    expect_true(all(risk[, -1] >= 0))
+    expect_true(all(risk[, -1] <= 1))
+    expect_true(all(risk_log[, -1] >= 0))
+    expect_true(all(risk_log[, -1] <= 1))
 })

--- a/tests/testthat/test-plotSingleEventCB.R
+++ b/tests/testthat/test-plotSingleEventCB.R
@@ -22,7 +22,8 @@ test_that("no error in plot method for singleEventCB objects - hazard function",
                        hazard.params = list(xvar = "eventtime",
                                             by = "trt",
                                             alpha = 0.05,
-                                            ylab = "Hazard")))
+                                            ylab = "Hazard")),
+                  silent = TRUE)
 
     expect_false(inherits(outglm, "try-error"))
 })
@@ -39,7 +40,8 @@ test_that("no error in plot method for singleEventCB objects - hazard ratio", {
                        hazard.params = list(xvar = "eventtime",
                                             by = "trt",
                                             alpha = 0.05,
-                                            ylab = "Hazard")))
+                                            ylab = "Hazard")),
+                  silent = TRUE)
 
     outglm_hr <- try(plot(mod_glm,
                           type = "hr",
@@ -47,8 +49,9 @@ test_that("no error in plot method for singleEventCB objects - hazard ratio", {
                           var = "trt",
                           increment = 1,
                           xvar = "eventtime",
-                          ci = T,
-                          rug = T))
+                          ci = TRUE,
+                          rug = TRUE),
+                     silent = TRUE)
 
     #using the exposed argument instead
     outglm_hr_exposed <- try(plot(mod_glm,
@@ -56,8 +59,9 @@ test_that("no error in plot method for singleEventCB objects - hazard ratio", {
                                   newdata = newdata,
                                   exposed = function(data) transform(data, trt = 1),
                                   xvar = "eventtime",
-                                  ci = T,
-                                  rug = T))
+                                  ci = TRUE,
+                                  rug = TRUE),
+                             silent = TRUE)
 
     expect_false(inherits(outglm, "try-error"))
     expect_false(inherits(outglm_hr, "try-error"))

--- a/vignettes/competingRisk.Rmd
+++ b/vignettes/competingRisk.Rmd
@@ -198,13 +198,6 @@ legend("topleft", legend = c("Log", "Spline"),
        pch = 19, col = c("red", "blue"))
 ```
 
-We can also estimate the mean absolute risk for the entire dataset:
-```{r eval=TRUE}
-mean(linearRisk)
-mean(logRisk)
-mean(splineRisk)
-```
-
 ## Session information
 
 ```{r echo=FALSE, eval=TRUE}

--- a/vignettes/smoothHazard.Rmd
+++ b/vignettes/smoothHazard.Rmd
@@ -145,7 +145,7 @@ model6 <- fitSmoothHazard(status ~ bs(time) + karno + diagtime + age + prior +
              celltype + trt, data = veteran, ratio = 100)
 summary(model6)
 
-absoluteRisk(object = model6, time = 90)
+str(absoluteRisk(object = model6, time = 90))
 ```
 
 As we can see from the summary, there is little evidence that splines actually improve the fit. Moreover, we can see that estimated individual absolute risks are essentially the same when using either a linear term or splines:


### PR DESCRIPTION
Addresses a couple issue with the output of `absoluteRisk`: 

- there's now an attribute that keeps track of whether `type = "CI"` or `type = "survival"` (but note that subsetting will [drop this attribute](https://twitter.com/mturg1989/status/1275583807270219777?s=20)). This fixes #119 
- I've removed an early edge case that we coded around, where the output of absolute risk dropped the time column if there was just one time point supplied. Now the output is consistent regardless of the length of `time`.

I've also increased the dependency on R as discussed (fixes #116 ) and cleaned up the code a bit.